### PR TITLE
Improve memory management, evaluation robustness, and per-bin metrics…

### DIFF
--- a/dctools/data/connection/config.py
+++ b/dctools/data/connection/config.py
@@ -19,10 +19,10 @@ class BaseConnectionConfig(ABC):
         self.params = SimpleNamespace(**kwargs)
         self.params.protocol = protocol
         # For ARGO/S3, local_root may be None - only check if provided
+        # Directory will be created lazily by download_file() when needed.
         if hasattr(self.params, "local_root") and self.params.local_root is not None:
             if not os.path.exists(self.params.local_root):
-                logger.error(f"Invalid path : {self.params.local_root}")
-                # raise FileNotFoundError()
+                logger.debug(f"local_root does not exist yet (will be created on demand): {self.params.local_root}")
 
     def to_dict(self) -> SimpleNamespace:
         """Convert configuration to dictionary."""

--- a/dctools/data/connection/connection_manager.py
+++ b/dctools/data/connection/connection_manager.py
@@ -514,6 +514,7 @@ class BaseConnectionManager(ABC):
             remote_path (str): Remote path of the file.
             local_path (str): Local path to save the file.
         """
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
         with self.params.fs.open(remote_path, "rb") as remote_file:
             with open(local_path, "wb") as local_file:
                 local_file.write(remote_file.read())
@@ -1326,10 +1327,10 @@ class GlonetManager(BaseConnectionManager):
         # Fast path: local zarr (prefetched by the driver)
         if not path.startswith(("https://", "http://", "s3://")):
             try:
-                return xr.open_zarr(path, consolidated=True)  # type: ignore[no-any-return]
+                return xr.open_zarr(path, consolidated=True, chunks={})  # type: ignore[no-any-return]
             except Exception:
                 try:
-                    return xr.open_zarr(path, consolidated=False)  # type: ignore[no-any-return]
+                    return xr.open_zarr(path, consolidated=False, chunks={})  # type: ignore[no-any-return]
                 except Exception:
                     pass
             return self.open_local(path)
@@ -1347,7 +1348,7 @@ class GlonetManager(BaseConnectionManager):
             Optional[xr.Dataset]: Opened dataset, or None if remote opening is not supported.
         """
         try:
-            glonet_ds: xr.Dataset = xr.open_zarr(path)
+            glonet_ds: xr.Dataset = xr.open_zarr(path, chunks={})
             return glonet_ds
 
         except Exception as exc:
@@ -1928,7 +1929,7 @@ class ArgoManager(BaseConnectionManager):
                     pass  # stale — rebuild
 
             t_start = _time_mod.time()
-            logger.debug(
+            logger.info(
                 f"ARGO monthly shared prefetch: full month {mkey} "
                 f"[{month_t0.date()} -> {month_t1.date()}]"
                 f" (batch window: {all_t0_in_month.date()} -> {all_t1_in_month.date()})"
@@ -2208,6 +2209,7 @@ def prefetch_obs_files_to_local(
     fs: Any,
     ref_alias: str = "",
     show_progress_bar: bool = True,
+    max_download_workers: Optional[int] = None,
 ) -> Dict[str, str]:
     """
     Pre-download observation files to local disk before worker dispatch.
@@ -2366,10 +2368,18 @@ def prefetch_obs_files_to_local(
         with _lock:
             _bar.update(1)
 
-    # ── Parallel downloads (4 concurrent connections) ─────────────
+    # ── Parallel downloads ──────────────────────────────────────────
+    # S3/Wasabi round-trip latency dominates for small obs files
+    # (SWOT ~12 MB, jason3 ~170 KB).  More concurrent threads =
+    # more requests in flight = better bandwidth utilisation.
+    # Scale with file count: many small files benefit most from
+    # high concurrency; cap at 32 to avoid fd/socket exhaustion.
     from concurrent.futures import ThreadPoolExecutor as _DlPool
 
-    _MAX_DL_WORKERS = min(8, len(unique_paths))
+    if max_download_workers is not None and max_download_workers > 0:
+        _MAX_DL_WORKERS = min(max_download_workers, len(unique_paths))
+    else:
+        _MAX_DL_WORKERS = min(max(16, len(unique_paths) // 20), 32, len(unique_paths))
     with _DlPool(max_workers=_MAX_DL_WORKERS) as pool:
         list(pool.map(_download_one, unique_paths))
 
@@ -2383,7 +2393,7 @@ def prefetch_obs_files_to_local(
         parts.append(f"{_stats['downloaded']} downloaded")
     if _stats["failed"]:
         parts.append(f"{_stats['failed']} FAILED")
-    logger.debug(f"Prefetch {ref_alias}: {' | '.join(parts)}")
+    logger.debug(f"Prefetch {ref_alias} ({_MAX_DL_WORKERS} threads): {' | '.join(parts)}")
     if _failures:
         for detail in _failures[:5]:
             logger.warning(f"  Prefetch failure: {detail}")

--- a/dctools/data/datasets/dataloader.py
+++ b/dctools/data/datasets/dataloader.py
@@ -1299,6 +1299,7 @@ def preprocess_batch_obs_files(
     n_points_dim: str = "n_points",
     output_zarr_dir: Optional[str] = None,
     eval_variables: Optional[List[str]] = None,
+    max_workers: Optional[int] = None,
 ) -> Optional[str]:
     """Preprocess all unique observation files on the driver into a single zarr.
 
@@ -1364,10 +1365,57 @@ def preprocess_batch_obs_files(
         try:
             _probe = xr.open_zarr(output_zarr_path, consolidated=False)
             if _probe.sizes.get(n_points_dim, 0) > 0:
+                _n_reuse = _probe.sizes[n_points_dim]
                 logger.debug(
                     f"Shared batch zarr ({alias}): reusing existing "
-                    f"({_probe.sizes[n_points_dim]:,} pts)"
+                    f"({_n_reuse:,} pts)"
                 )
+                # Ensure time sidecar exists (may be missing from older runs).
+                _time_npy_reuse = os.path.join(
+                    output_zarr_dir, "time_index.npy"
+                )
+                _time_coord_reuse = coordinates.get("time", "time")
+                if (
+                    not os.path.exists(_time_npy_reuse)
+                    and _time_coord_reuse in _probe.variables
+                ):
+                    logger.info(
+                        f"Shared batch ({alias}): building missing "
+                        f"time_index.npy for reused zarr ({_n_reuse:,} pts)"
+                    )
+                    try:
+                        _t_mmap = np.lib.format.open_memmap(
+                            _time_npy_reuse,
+                            mode="w+",
+                            dtype="datetime64[ns]",
+                            shape=(_n_reuse,),
+                        )
+                        _CSZ_R = 100_000
+                        _tvar = _probe[_time_coord_reuse]
+                        for _sr in range(0, _n_reuse, _CSZ_R):
+                            _er = min(_sr + _CSZ_R, _n_reuse)
+                            _cv = _tvar.isel(
+                                {n_points_dim: slice(_sr, _er)}
+                            ).values
+                            _cv = np.asarray(_cv)
+                            if np.issubdtype(_cv.dtype, np.integer):
+                                _cv = _cv.astype("datetime64[ns]")
+                            elif not np.issubdtype(
+                                _cv.dtype, np.datetime64
+                            ):
+                                _cv = pd.to_datetime(_cv).values
+                            _t_mmap[_sr:_er] = _cv
+                            del _cv
+                        del _t_mmap
+                        logger.info(
+                            f"Shared batch ({alias}): time_index.npy "
+                            f"built ({_n_reuse:,} pts)"
+                        )
+                    except Exception as _exc_npy:
+                        logger.warning(
+                            f"Shared batch ({alias}): cannot build "
+                            f"time sidecar: {_exc_npy!r}"
+                        )
                 _probe.close()
                 return output_zarr_path
             _probe.close()
@@ -1409,17 +1457,16 @@ def preprocess_batch_obs_files(
     n_pts_total = 0
 
     _cpu_count = os.cpu_count() or 4
-    _env_max = int(os.environ.get("DCTOOLS_PREP_WORKERS", "0"))
 
     # ── Executor selection ────────────────────────────────────────────────
     # Default: ProcessPoolExecutor (fork on Linux).
-    # Each worker process has its own GIL → swath_to_points (xr.stack +
+    # Each worker process has its own GIL --> swath_to_points (xr.stack +
     # reset_index, which are pure-Python/pandas and hold the GIL) runs in
     # true parallel.  ThreadPoolExecutor serialises all Python-heavy ops on
     # a single CPU despite having multiple threads.
     #
     # Memory: each forked child adds ~150–300 MB RSS (most Python/library
-    # pages are read-only → truly shared via Linux mmap; only numpy arrays
+    # pages are read-only --> truly shared via Linux mmap; only numpy arrays
     # of the current file trigger copy-on-write).  With 4 workers the
     # overhead is ~0.6–1.2 GB, acceptable on any machine running DC1.
     #
@@ -1429,12 +1476,14 @@ def preprocess_batch_obs_files(
         "DCTOOLS_PREP_USE_THREADS", ""
     ).lower() not in ("1", "true", "yes")
 
-    # Cap at 4 processes (conservative for RAM).  With threads the GIL
-    # would bottleneck anyway, so 8 threads give no real benefit — keep
-    # the same cap for consistency when the user overrides to threads.
-    _default_max = 4
+    # Use most available CPUs for preprocessing.  During this phase the
+    # Dask cluster is idle (no tasks submitted yet), so it is safe to
+    # use all the cores that would otherwise be assigned to workers.
+    # Memory: each forked child adds ~150-300 MB RSS.  Cap at 16 to
+    # keep peak RSS under 4.8 GB even on high-core-count machines.
+    _default_max = max(max_workers or 0, min(_cpu_count * 3 // 4, 16))
     _MAX_PREP_WORKERS = min(
-        _env_max if _env_max > 0 else min(_cpu_count, _default_max),
+        min(_cpu_count, _default_max),
         len(local_paths),
     )
 
@@ -1446,7 +1495,7 @@ def preprocess_batch_obs_files(
     ]
 
     _t_phase1_start = _time.perf_counter()
-    logger.info(
+    logger.debug(
         f"Shared batch preprocessing ({alias}): "
         f"{len(local_paths)} unique files, "
         f"{_MAX_PREP_WORKERS} {'processes' if _use_processes else 'threads'}"
@@ -1501,7 +1550,7 @@ def preprocess_batch_obs_files(
                 _collect_phase1_result(fut, _fut_to_path)
 
     _t_phase1_elapsed = _time.perf_counter() - _t_phase1_start
-    logger.info(
+    logger.debug(
         f"Shared batch ({alias}): Phase 1 done — "
         f"{n_ok}/{len(local_paths)} files, {n_pts_total:,} pts "
         f"in {_t_phase1_elapsed:.1f}s"
@@ -1513,7 +1562,7 @@ def preprocess_batch_obs_files(
         return None
 
     # ── Pre-sort mini-zarrs by first time element ─────────────────────────
-    # t_start was returned by _process_file_to_zarr (data was in memory →
+    # t_start was returned by _process_file_to_zarr (data was in memory -->
     # no extra I/O needed here, unlike the previous sequential re-open loop).
     _time_name = coordinates.get("time", "time")
     if len(_mini_zarr_paths) > 1:
@@ -1536,10 +1585,10 @@ def preprocess_batch_obs_files(
         )
 
     _t_phase2_start = _time.perf_counter()
-    # ── Parallel merge → shared zarr ────────────────────────────────────
+    # ── Parallel merge --> shared zarr ────────────────────────────────────
     # Build a lazy xr.concat of all mini-zarrs (zero data in memory) then
     # let Dask write all output chunks in parallel.  Pre-sorted mini-zarrs
-    # guarantee the output is already time-ordered → no sortby needed.
+    # guarantee the output is already time-ordered --> no sortby needed.
     #
     # Why this is safe (memory):
     #   Each Dask task reads exactly ONE 100 K-point input chunk and writes
@@ -1555,7 +1604,14 @@ def preprocess_batch_obs_files(
 
     _TARGET_CHUNK = 100_000  # uniform chunk size along n_points_dim
     _time_name_coord = coordinates.get("time", "time")
-    _TIME_NPY_MAX_GB = float(os.environ.get("DCTOOLS_TIME_NPY_MAX_GB", "1.0"))
+    # 3.0 GB threshold: for a 189 M-point SWOT batch the time array is
+    # ~1.51 GB.  Building the sidecar once in the driver (before any
+    # worker task runs) costs that amount temporarily; skipping it forces
+    # every worker to load the full time array individually (×5 = 7.5 GB
+    # wasted worker RAM --> OOM on 32 GB machines).  The higher threshold
+    # keeps the driver spike well within budget while eliminating the
+    # per-worker eager load for all realistic batch sizes.
+    _TIME_NPY_MAX_GB = 3.0
     _time_npy_size_gb = n_pts_total * 8 / 1e9
     _time_npy_path = os.path.join(output_zarr_dir, "time_index.npy")
 
@@ -1612,34 +1668,46 @@ def preprocess_batch_obs_files(
     if _time_enc and "time" in _combined.variables:
         _combined["time"].encoding.update(_time_enc)
 
-    # 6. Write using local threads (Blosc releases GIL → all cores active).
-    #    IMPORTANT: Always use a local thread pool, never the distributed
-    #    client.  When the distributed workers process the merge, zarr/blosc
-    #    internal buffers accumulate as "unmanaged memory" that the OS does
-    #    not reclaim.  For large SWATH datasets (e.g. 217 M-point SWOT) this
-    #    can consume 4+ GiB per worker — leaving no headroom for the actual
-    #    evaluation tasks that follow immediately.  Local threads keep the
-    #    distributed workers' memory pristine for evaluation.
+    # 6. Write using a LOCAL threaded scheduler on the driver.
+    #    IMPORTANT: the string "threads" gets intercepted by the active
+    #    distributed Client in dask >= 2025, routing chunk tasks to cluster
+    #    workers where zarr/blosc buffers accumulate as unmanaged memory.
+    #    FIX: pass the actual callable `dask.threaded.get` to
+    #    `dask.compute()` — this bypasses Client dispatch entirely.
+    #    All threads run in the driver process, keeping distributed workers'
+    #    memory pristine while achieving parallel I/O (typically 4-8×
+    #    faster than synchronous for large SWATH merges).
     import dask as _dask_merge
+    from dask.threaded import get as _threaded_get
+    _merge_workers = min(os.cpu_count() or 4, 8)
     logger.debug(
         f"Shared batch ({alias}): merging {len(_lazy_parts)} mini-zarrs "
-        f"→ {output_zarr_path} using {_MAX_PREP_WORKERS} local threads"
+        f"--> {output_zarr_path} using threaded scheduler "
+        f"({_merge_workers} driver-local threads)"
     )
-    with _dask_merge.config.set(
-        scheduler="threads", num_workers=_MAX_PREP_WORKERS
-    ):
-        _combined.to_zarr(output_zarr_path, mode="w")
+    _delayed_write = _combined.to_zarr(output_zarr_path, mode="w", compute=False)
+    _dask_merge.compute(_delayed_write, scheduler=_threaded_get, num_workers=_merge_workers)
 
-    del _combined, _lazy_parts
+    del _combined
     gc.collect()
 
-    # 7. Build time sidecar (.npy) from the written zarr in one sequential pass
-    if _time_npy_size_gb <= _TIME_NPY_MAX_GB and n_pts_total > 0 and _time_name_coord:
+    # 7. Build time sidecar (.npy) from the MERGED zarr using threaded I/O.
+    #    Reading one large contiguous array from the merged zarr is faster
+    #    than iterating over hundreds of mini-zarrs (avoids per-file
+    #    open_zarr overhead).  Workers mmap the sidecar (mmap_mode='r') so
+    #    the OS shares physical pages across all workers --> ~0 worker RSS.
+    if n_pts_total > 0 and _time_name_coord:
         try:
-            _sc_ds = xr.open_zarr(output_zarr_path, consolidated=False)
-            if _time_name_coord in _sc_ds.variables:
-                _tv = np.asarray(_sc_ds[_time_name_coord].values)
-                _sc_ds.close()
+            _merged_probe = xr.open_zarr(
+                output_zarr_path, consolidated=False,
+                chunks={n_points_dim: _TARGET_CHUNK},
+            )
+            if _time_name_coord in _merged_probe.variables:
+                _time_da = _merged_probe[_time_name_coord]
+                # Read using threaded scheduler for parallel chunk I/O
+                _tv = _dask_merge.compute(
+                    _time_da.data, scheduler=_threaded_get, num_workers=_merge_workers
+                )[0]
                 if np.issubdtype(_tv.dtype, np.integer):
                     _tv = _tv.astype("datetime64[ns]")
                 elif not np.issubdtype(_tv.dtype, np.datetime64):
@@ -1652,17 +1720,12 @@ def preprocess_batch_obs_files(
                     f"({len(_tv):,} pts) to {_time_npy_path}"
                 )
                 del _tv
-            else:
-                _sc_ds.close()
+            _merged_probe.close()
         except Exception as _exc_sc:
             logger.debug(f"Time sidecar build failed: {_exc_sc}")
-    elif _time_npy_size_gb > _TIME_NPY_MAX_GB:
-        logger.debug(
-            f"Shared batch ({alias}): skipping time index .npy "
-            f"(estimated {_time_npy_size_gb:.2f} GB > "
-            f"limit {_TIME_NPY_MAX_GB} GB). "
-            "Workers will read time from the shared zarr."
-        )
+
+    del _lazy_parts
+    gc.collect()
 
     # Consolidate metadata so worker threads don't each stat hundreds
     # of small .zarray/.zattrs files simultaneously.
@@ -1673,7 +1736,7 @@ def preprocess_batch_obs_files(
         pass  # non-critical — workers fall back to consolidated=False
 
     _t_phase2_elapsed = _time.perf_counter() - _t_phase2_start
-    logger.info(
+    logger.debug(
         f"Shared batch ({alias}): Phase 2 done — "
         f"merged {len(_mini_zarr_paths)} mini-zarrs in {_t_phase2_elapsed:.1f}s"
     )

--- a/dctools/data/datasets/dataset.py
+++ b/dctools/data/datasets/dataset.py
@@ -615,8 +615,6 @@ def get_dataset_from_config(
                 logger.info(f"Using ARGO directory catalog at {path}")
                 catalog_path = path
 
-    if not os.path.exists(data_root):
-        os.mkdir(data_root)
     if not os.path.exists(root_catalog_folder):
         os.mkdir(root_catalog_folder)
 

--- a/dctools/metrics/evaluator.py
+++ b/dctools/metrics/evaluator.py
@@ -1,11 +1,34 @@
 """Metrics evaluator module for distributed evaluation."""
 
 import gc
+import gzip
 import json
 import os
 import time
 import traceback
 import ctypes
+
+# ── glibc arena cap ──────────────────────────────────────────────────────
+# Must be set BEFORE LocalCluster forks worker processes so that glibc
+# in each fresh worker honours it from the very first malloc().  Without
+# this, glibc defaults to 8×N_CORES arenas (e.g. 176 on a 22-core
+# machine), each retaining fragmented pages that malloc_trim(0) cannot
+# reclaim — manifesting as multi-GiB "unmanaged memory" in Dask workers.
+os.environ.setdefault("MALLOC_ARENA_MAX", "2")
+
+# ── GLIBC_TUNABLES ──────────────────────────────────────────────────────
+# Unlike mallopt() (which we call later in _configure_mallopt_once), the
+# GLIBC_TUNABLES env var is read by glibc at *process start* — before
+# any Python code runs.  This guarantees that worker processes forked by
+# LocalCluster use the correct mmap threshold from their first allocation.
+# mallopt() only affects *future* allocations and by the time our code
+# runs, glibc may have already raised its dynamic mmap threshold.
+os.environ.setdefault(
+    "GLIBC_TUNABLES",
+    "glibc.malloc.mmap_threshold=131072"
+    ":glibc.malloc.trim_threshold=131072"
+    ":glibc.malloc.arena_max=2",
+)
 from argparse import Namespace
 from typing import Any, Callable, Dict, List, Optional
 
@@ -64,13 +87,9 @@ def _open_dataset_worker_cached(
     """Open a dataset with a small per-worker LRU cache.
 
     This primarily targets remote Zarr datasets (S3/Wasabi) where repeated
-    open calls are expensive (metadata reads). Cache size can be tuned via
-    `DCTOOLS_WORKER_DATASET_CACHE_SIZE`.
+    open calls are expensive (metadata reads).
     """
-    try:
-        cache_size = int(os.environ.get("DCTOOLS_WORKER_DATASET_CACHE_SIZE", "4"))
-    except Exception:
-        cache_size = 4
+    cache_size = 4
 
     if cache_size <= 0:
         return open_func(source), False
@@ -155,12 +174,39 @@ from dctools.utilities.misc_utils import (  # noqa: E402
 )
 
 
+def _configure_mallopt_once():
+    """Set glibc malloc parameters via mallopt() — call at least once per process.
+
+    os.environ['MALLOC_MMAP_THRESHOLD_'] only works at ptmalloc init time
+    (first malloc call after process start).  For Dask workers spawned by
+    LocalCluster(processes=True), that ship has sailed by the time our code
+    runs.  mallopt() changes the thresholds for all *future* allocations.
+
+    M_MMAP_THRESHOLD = 128 KB  -->  numpy/pandas buffers ≥128 KB are allocated
+    via mmap() and released back to the OS immediately on free (munmap),
+    preventing the glibc sbrk heap fragmentation that causes Dask's
+    "Unmanaged memory use is high" warnings.
+
+    """
+    if getattr(_configure_mallopt_once, '_done', False):
+        return
+    try:
+        _libc = ctypes.CDLL('libc.so.6')
+        _libc.mallopt(-1, 131072)   # M_TRIM_THRESHOLD  = 128 KB
+        _libc.mallopt(-3, 131072)   # M_MMAP_THRESHOLD  = 128 KB
+        _libc.mallopt(-8, 2)        # M_ARENA_MAX = 2 (belt-and-suspenders)
+        _configure_mallopt_once._done = True
+    except Exception:
+        pass
+
+
 def worker_memory_cleanup():
     """
     Manual memory cleanup to be run on workers.
 
     Performs aggressive garbage collection and memory trimming.
     """
+    _configure_mallopt_once()
     # Single gc.collect() is sufficient — 3× adds overhead per call
     gc.collect()
 
@@ -191,6 +237,101 @@ def _clear_xarray_file_cache() -> bool:
         return False
 
 
+def _log_memory_status(label: str = "") -> str:
+    """Return a one-line memory summary (system + current process RSS)."""
+    import os as _os
+    try:
+        # System-level available memory
+        with open("/proc/meminfo") as _f:
+            _mi = {}
+            for _l in _f:
+                _parts = _l.split()
+                if len(_parts) >= 2:
+                    _mi[_parts[0].rstrip(":")] = int(_parts[1])
+        _total_gb = _mi.get("MemTotal", 0) / 1048576
+        _avail_gb = _mi.get("MemAvailable", 0) / 1048576
+        _swap_used_gb = (_mi.get("SwapTotal", 0) - _mi.get("SwapFree", 0)) / 1048576
+    except Exception:
+        _total_gb = _avail_gb = _swap_used_gb = -1
+    try:
+        # Current process RSS
+        with open(f"/proc/{_os.getpid()}/status") as _f:
+            _rss_kb = 0
+            for _l in _f:
+                if _l.startswith("VmRSS:"):
+                    _rss_kb = int(_l.split()[1])
+                    break
+        _rss_mb = _rss_kb / 1024
+    except Exception:
+        _rss_mb = -1
+    _msg = (
+        f"[MEM {label}] pid={_os.getpid()} RSS={_rss_mb:.0f}MB | "
+        f"System: {_avail_gb:.1f}/{_total_gb:.1f}GB avail, "
+        f"swap_used={_swap_used_gb:.1f}GB"
+    )
+    return _msg
+
+
+def _cap_openblas_via_proc_maps(n_threads: int = 1) -> None:
+    """Cap ALL OpenBLAS libraries loaded in the current process.
+
+    NumPy's pip wheel bundles its own ``libopenblas64_p*.so`` whose symbols
+    are suffixed with ``64_`` (e.g. ``openblas_set_num_threads64_``).
+    SciPy bundles ``libscipy_openblas*.so`` with ``scipy_`` prefix
+    (e.g. ``scipy_openblas_set_num_threads``).
+    The system ``libopenblas.so`` uses un-suffixed symbols.  All three may
+    be loaded simultaneously.  Scanning ``/proc/self/maps`` lets us find
+    every loaded variant and cap them all.
+    """
+    import ctypes as _ct
+    import os as _os
+
+    # All known symbol names for setting the OpenBLAS thread count.
+    _SETTER_SYMBOLS = (
+        "openblas_set_num_threads64_",    # numpy-bundled 64-bit
+        "openblas_set_num_threads",        # standard / system
+        "scipy_openblas_set_num_threads",  # scipy-bundled (prefixed)
+        "scipy_goto_set_num_threads",      # scipy goto variant
+        "goto_set_num_threads",            # GotoBLAS legacy
+    )
+
+    _seen: set = set()
+    try:
+        with open(f"/proc/{_os.getpid()}/maps") as _f:
+            for _line in _f:
+                if "openblas" not in _line.lower():
+                    continue
+                _parts = _line.split()
+                if len(_parts) < 6:
+                    continue
+                _path = _parts[-1]
+                if not _path.startswith("/") or _path in _seen:
+                    continue
+                _seen.add(_path)
+                try:
+                    _lib = _ct.CDLL(_path)
+                except Exception:
+                    continue
+                # Try every known symbol name; cap all that exist.
+                for _set_sym in _SETTER_SYMBOLS:
+                    try:
+                        _setter = getattr(_lib, _set_sym)
+                        _setter(n_threads)
+                    except AttributeError:
+                        continue
+    except Exception:
+        pass
+
+    # Last-resort: try the linker-visible name (covers cases where
+    # /proc/maps is unavailable, e.g. Docker --pid=host).
+    for _name in ("libopenblas.so", "libopenblas64.so"):
+        try:
+            _lib = _ct.CDLL(_name)
+            _lib.openblas_set_num_threads(n_threads)
+        except Exception:
+            pass
+
+
 def _worker_full_cleanup() -> bool:
     """Full cleanup routine to run on workers via client.run()."""
     import os
@@ -204,6 +345,11 @@ def _worker_full_cleanup() -> bool:
     }
     for key, value in env_vars.items():
         os.environ[key] = value
+
+    # Actually configure glibc malloc at runtime via mallopt().
+    # os.environ['MALLOC_*'] only works before ptmalloc init — useless
+    # in a Dask worker that has already called malloc thousands of times.
+    _configure_mallopt_once()
 
     # Cap library-level threads to prevent CPU oversubscription
     # (pyinterp, BLAS, OpenMP, torch, etc.)
@@ -232,17 +378,31 @@ def _worker_full_cleanup() -> bool:
     try:
         import threadpoolctl
         threadpoolctl.threadpool_limits(limits=1)
+    except ImportError:
+        pass
     except Exception:
         pass
-    # allow 2 threads for decent decompression speed on Blosc-compressed SWOT HDF5 chunks.
+
+    # ── OpenBLAS: direct C-level cap (belt-and-suspenders) ───────────
+    # The env vars above only work if set BEFORE numpy is imported.
+    # In a Dask worker the library is already loaded, so resizing the
+    # thread pool requires a direct call into the shared library.
+    # NumPy bundles its own libopenblas64_p*.so with 64-bit integer
+    # symbols (openblas_set_num_threads64_) — different from the system
+    # libopenblas.so.  We must scan /proc/self/maps to find ALL loaded
+    # OpenBLAS variants and cap them all.
+    _cap_openblas_via_proc_maps(1)
+
+    # Blosc decompression — cap to 1 thread per worker to avoid CPU
+    # oversubscription (5 workers × 2 blosc threads = 10 extra threads).
     try:
         import blosc  # type: ignore[import-not-found]
-        blosc.set_nthreads(2)
+        blosc.set_nthreads(1)
     except Exception:
         pass
     try:
         from numcodecs import blosc as _nc_blosc  # type: ignore[import-untyped]
-        _nc_blosc.set_nthreads(2)
+        _nc_blosc.set_nthreads(1)
     except Exception:
         pass
 
@@ -358,12 +518,15 @@ def _cap_worker_threads(max_threads: int = 1) -> None:
     except Exception:
         pass
 
+    # ── OpenBLAS: direct C-level cap as fallback ─────────────────────
+    # When threadpoolctl is not installed, resize OpenBLAS manually.
+    # Must target ALL loaded variants (system + numpy-bundled 64-bit).
+    _cap_openblas_via_proc_maps(max_threads)
+
     # ── Blosc: NOT covered by threadpoolctl — cap explicitly ──────────
-    # The Blosc compression library uses its own internal thread pool
-    # (independent of OpenMP and BLAS).  SWOT NetCDF/Zarr files are
-    # typically Blosc-compressed; allow a small number of threads (2)
-    # for decent decompression throughput without oversubscribing CPUs.
-    _blosc_threads = max(2, max_threads)
+    # Blosc decompression — cap to max_threads (1 by default) to avoid
+    # CPU oversubscription (N workers × K blosc threads adds up fast).
+    _blosc_threads = max(1, max_threads)
     try:
         import blosc
         blosc.set_nthreads(_blosc_threads)
@@ -409,14 +572,12 @@ def compute_metric(
     """
     try:
         # ── Prevent CPU oversubscription ──
-        # Observation datasets (SWOT, saral, …) trigger pyinterp
-        # bilinear interpolation which is CPU-bound C++ code that
-        # releases the GIL.  With 8 workers × 2 threads × 4 pyinterp
-        # threads the machine (16 physical cores) gets massively
-        # oversubscribed -> 100 % CPU thrashing.
-        # Cap library-level threads to 1 so only the Dask thread
-        # concurrency controls parallelism.
-        _cap_worker_threads(1)
+        # Cap C-library threads (pyinterp, BLAS, OpenMP, Blosc) to the
+        # per-dataset value injected by _evaluate_batch from the YAML
+        # key ``c_lib_threads`` (default 1).
+        _c_lib_threads = int(entry.get("_c_lib_threads", 1))
+        _cap_worker_threads(_c_lib_threads)
+        logger.debug(_log_memory_status("task-start"))
         _t0_total = time.perf_counter()
         forecast_reference_time = entry.get("forecast_reference_time")
         lead_time = entry.get("lead_time")
@@ -557,6 +718,34 @@ def compute_metric(
                 ds = ds[keep_data_vars]
             return ds
 
+        # ── Slim prediction to variables the metric actually needs ─────
+        # When the reference is an observation dataset, the metric only
+        # compares variables that share a standardized name (e.g. SWOT
+        # only uses SSH --> prediction only needs 'zos').  Dropping
+        # unused 3-D fields (so, thetao, uo, vo) avoids materialising
+        # hundreds of MiB of data that would never be evaluated.
+        if ref_is_observation and hasattr(pred_data, "data_vars"):
+            _metric_vars = _required_obs_vars()
+            if _metric_vars:
+                from dctools.data.coordinates import get_standardized_var_name as _std_vname
+                _std_needed = {_std_vname(v) for v in _metric_vars}
+                _std_needed.discard(None)
+                if _std_needed:
+                    _pred_keep_for_ref = [
+                        v for v in pred_data.data_vars
+                        if _std_vname(str(v)) in _std_needed
+                    ]
+                    if (
+                        _pred_keep_for_ref
+                        and len(_pred_keep_for_ref) < len(pred_data.data_vars)
+                    ):
+                        logger.debug(
+                            f"[{ref_alias}] Slimming prediction: keeping "
+                            f"{_pred_keep_for_ref} (dropped "
+                            f"{sorted(set(pred_data.data_vars) - set(_pred_keep_for_ref))})"
+                        )
+                        pred_data = pred_data[_pred_keep_for_ref]
+
         if ref_source is not None:
             if ref_is_observation:
                 # Observation entry is a dict with connection metadata;
@@ -641,7 +830,7 @@ def compute_metric(
                             _xr_argo.open_zarr(
                                 p,
                                 consolidated=True,
-                                chunks=None,
+                                chunks={},
                             )
                             for p in _zarr_paths
                         ]
@@ -695,8 +884,8 @@ def compute_metric(
                                 _mask = (_t_vals >= _t0_np) & (_t_vals <= _t1_np)
                                 ref_data = ref_data.isel({n_points_dim: _mask})
 
-                        # With chunks=None the data is already NumPy;
-                        # .compute() is only needed if still dask-backed.
+                        # With chunks={} the data is dask-backed;
+                        # .compute() materialises only the time-filtered slice.
                         if any(
                             hasattr(ref_data[v].data, "dask")
                             for v in ref_data.variables
@@ -809,45 +998,125 @@ def compute_metric(
                                     ).astype("datetime64[ns]")
 
                             if _time_vals is None:
-                                # Fallback: load time from zarr (expensive).
+                                # Fallback: build sidecar .npy by streaming
+                                # from zarr in chunks (no full-array spike).
                                 _time_var = ref_data.coords.get("time")
                                 if _time_var is not None:
-                                    if hasattr(_time_var, "compute"):
-                                        _time_vals = _time_var.compute(
-                                            scheduler="synchronous"
-                                        ).values
-                                    else:
-                                        _time_vals = _time_var.values
-                                    _time_vals = np.asarray(_time_vals)
-                                    if np.issubdtype(
-                                        _time_vals.dtype, np.integer
-                                    ):
-                                        _time_vals = _time_vals.astype(
-                                            "datetime64[ns]"
+                                    _n_total = _time_var.sizes.get(
+                                        n_points_dim,
+                                        _time_var.size,
+                                    )
+                                    try:
+                                        _time_mmap = np.lib.format.open_memmap(
+                                            _time_npy,
+                                            mode="w+",
+                                            dtype="datetime64[ns]",
+                                            shape=(_n_total,),
                                         )
-                                    elif not np.issubdtype(
-                                        _time_vals.dtype, np.datetime64
-                                    ):
-                                        _time_vals = pd.to_datetime(
-                                            _time_vals
-                                        ).values
+                                        _CSZ = 100_000
+                                        for _s in range(0, _n_total, _CSZ):
+                                            _e = min(_s + _CSZ, _n_total)
+                                            _chunk = _time_var.isel(
+                                                {n_points_dim: slice(_s, _e)}
+                                            )
+                                            _cv = (
+                                                _chunk.compute(
+                                                    scheduler="synchronous"
+                                                ).values
+                                                if hasattr(_chunk, "compute")
+                                                else _chunk.values
+                                            )
+                                            _cv = np.asarray(_cv)
+                                            if np.issubdtype(
+                                                _cv.dtype, np.integer
+                                            ):
+                                                _cv = _cv.astype(
+                                                    "datetime64[ns]"
+                                                )
+                                            elif not np.issubdtype(
+                                                _cv.dtype, np.datetime64
+                                            ):
+                                                _cv = pd.to_datetime(
+                                                    _cv
+                                                ).values
+                                            _time_mmap[_s:_e] = _cv
+                                            del _cv, _chunk
+                                        del _time_mmap
+                                        # Now mmap the freshly-built sidecar.
+                                        _time_vals = np.load(
+                                            _time_npy, mmap_mode="r"
+                                        )
+                                        logger.info(
+                                            "Built time_index.npy sidecar "
+                                            "(%d pts) for %s",
+                                            _n_total,
+                                            _time_npy,
+                                        )
+                                    except (OSError, PermissionError):
+                                        # Cannot write sidecar (read-only FS);
+                                        # fall back to in-memory load.
+                                        logger.warning(
+                                            "Cannot write time_index.npy; "
+                                            "loading time array in memory."
+                                        )
+                                        if hasattr(_time_var, "compute"):
+                                            _time_vals = _time_var.compute(
+                                                scheduler="synchronous"
+                                            ).values
+                                        else:
+                                            _time_vals = _time_var.values
+                                        _time_vals = np.asarray(_time_vals)
+                                        if np.issubdtype(
+                                            _time_vals.dtype, np.integer
+                                        ):
+                                            _time_vals = _time_vals.astype(
+                                                "datetime64[ns]"
+                                            )
+                                        elif not np.issubdtype(
+                                            _time_vals.dtype, np.datetime64
+                                        ):
+                                            _time_vals = pd.to_datetime(
+                                                _time_vals
+                                            ).values
 
                             if _time_vals is not None:
-                                # The shared zarr is always time-sorted
-                                # (see preprocess_batch_obs_files), so
-                                # use contiguous slice indexing — reads
-                                # ONLY the relevant chunks instead of
-                                # scanning all 107 M points.
-                                _i0 = int(
-                                    np.searchsorted(
-                                        _time_vals, _t0, side="left",
-                                    )
-                                )
-                                _i1 = int(
-                                    np.searchsorted(
-                                        _time_vals, _t1, side="right",
-                                    )
-                                )
+                                # ── Binary-search time filter (O(log N)) ─
+                                # preprocess_batch_obs_files writes mini-
+                                # zarrs in time order and concatenates them
+                                # in that order --> time_index.npy is
+                                # monotonically non-decreasing.
+                                # Corrupt 1970-epoch timestamps (if any)
+                                # are datetime64 values < any valid 2024
+                                # date, so they sort first and searchsorted
+                                # for _t0 ≥ 2024 skips them correctly.
+                                #
+                                # CRITICAL: a full boolean scan
+                                #   (_time_vals >= _t0) & (_time_vals <= _t1)
+                                # forces the OS to page-in ALL N elements of
+                                # the mmap (3.64 GiB for a 455 M-point
+                                # batch).  With 5 concurrent workers each
+                                # mmapping the same file, each worker's RSS
+                                # grows by ~3.64 GiB "unmanaged" memory,
+                                # triggering 95 % worker kills before any
+                                # metric is computed.
+                                # searchsorted uses ~28 comparisons (binary
+                                # bisection) --> only ~112 KB of pages touched
+                                # per worker, eliminating the memory spike.
+                                _t0_ns = np.datetime64(_t0, "ns")
+                                _t1_ns = np.datetime64(_t1, "ns")
+                                _i0 = int(np.searchsorted(
+                                    _time_vals, _t0_ns, side="left"
+                                ))
+                                _i1 = int(np.searchsorted(
+                                    _time_vals, _t1_ns, side="right"
+                                ))
+
+                                del _time_vals
+                                _time_vals = None
+
+                                if _i0 >= _i1:
+                                    _i0, _i1 = 0, 0
+
                                 ref_data = ref_data.isel(
                                     {
                                         n_points_dim: slice(_i0, _i1)
@@ -862,9 +1131,16 @@ def compute_metric(
                             if reduce_precision:
                                 ref_data = to_float32(ref_data)
 
-                            ref_data = ref_data.compute(
-                                scheduler="synchronous"
-                            )
+                            # ── Keep ref_data lazy (dask-backed) ───────
+                            # Do NOT call .compute() here. The Class4
+                            # metric's xr_to_obs_dataframe() streams
+                            # over n_points in 500 K-point chunks when
+                            # the dataset is dask-backed — peak worker
+                            # RSS ≈ one chunk (~16 MB) instead of the
+                            # full slice (potentially several GiB).
+                            # Materialising 151 M obs points × 32 B =
+                            # 4.8 GiB would leave no headroom in a 6 GB
+                            # worker, causing OOM on large SWOT batches.
 
                             if ref_data.sizes.get(
                                 n_points_dim, 0
@@ -1054,6 +1330,37 @@ def compute_metric(
                 "lead_time": lead_time,
                 "valid_time": valid_time,
             }
+
+        # ── Surface-depth selection for surface-only observation refs ──
+        # When the reference is a surface-only observation (SWOT, SARAL,
+        # Jason3) — i.e. no "depth" dimension in ref_data — there is no
+        # point loading all 21 depth levels of the prediction.
+        #
+        # Concretely for SWOT: glonet zos has shape (10, 21, 672, 1440).
+        # After variable slimming we keep only zos, but still carry
+        # 21 depth levels --> 10 × 21 × 672 × 1440 × 4 B = 813 MB per
+        # worker call to _compute_with_timeout.  With 3 workers doing
+        # this simultaneously that is 2.4 GiB of "unmanaged" memory just
+        # from the prediction, before any metric computation starts.
+        #
+        # Slicing to depth=0 (lazy, O(1)) reduces this to 38.7 MB —
+        # a 21× reduction — without any loss of scientific accuracy
+        # because SWOT / SARAL / Jason3 only measure surface SSH.
+        #
+        # Argo-profile refs DO have a "depth" coord --> skip this path.
+        _ref_has_depth_dim = (
+            ref_data is not None
+            and hasattr(ref_data, "dims")
+            and "depth" in ref_data.dims
+        )
+        if (
+            ref_is_observation
+            and not _ref_has_depth_dim
+            and pred_data is not None
+            and "depth" in getattr(pred_data, "dims", [])
+        ):
+            pred_data = pred_data.isel(depth=0)
+
         # Compute once after transforms (safe & memory-friendlier).
         if hasattr(pred_data, 'chunks') and pred_data.chunks:
             # Use a hard Python-level timeout instead of bare .compute().
@@ -1072,8 +1379,22 @@ def compute_metric(
 
         if ref_data is not None and ref_transform is not None:
             ref_data = ref_transform(ref_data)
-            # Re-materialize if transform produced new lazy arrays
-            if hasattr(ref_data, 'chunks') and ref_data.chunks:
+            # Apply float32 reduction lazily *before* compute so the cast is
+            # fused into the single compute pass — no separate in-memory copy
+            # of the materialised arrays is needed afterwards.
+            if (
+                reduce_precision and ref_data is not None
+                and hasattr(ref_data, 'chunks') and ref_data.chunks
+                and not (ref_is_observation and _used_prefetch)
+            ):
+                ref_data = to_float32(ref_data)
+            # Re-materialize if transform produced new lazy arrays —
+            # but SKIP for observation shared-zarr refs: those must stay
+            # dask-backed so the metric's chunk streaming works.
+            if (
+                hasattr(ref_data, 'chunks') and ref_data.chunks
+                and not (ref_is_observation and _used_prefetch)
+            ):
                 _s3_timeout = int(os.environ.get("DCTOOLS_S3_COMPUTE_TIMEOUT", "90"))
                 ref_data = _compute_with_timeout(
                     ref_data, timeout_s=_s3_timeout, scheduler="synchronous"
@@ -1081,8 +1402,11 @@ def compute_metric(
 
         if reduce_precision:
             # pred_data is already float32.
+            # For ref_data: if it was dask-backed above, the cast was already
+            # applied lazily before compute (no-op here for the common path).
+            # Fallback for paths that produced a non-dask ref (e.g. CMEMS).
             if ref_data is not None:
-                ref_data = to_float32(ref_data)
+                ref_data = to_float32(ref_data)  # no-op when already float32
 
         # Force reloading if memory becomes an issue? No, trust Dask, but do explicit GC
         _clear_xarray_file_cache()
@@ -1133,7 +1457,10 @@ def compute_metric(
                 f"{n_points_raw} obs points — starting metric computation…"
             )'''
 
-            _cap_worker_threads(1)
+            # Re-cap C-library threads before metric computation using
+            # the per-dataset value from the YAML config.
+            _cap_worker_threads(_c_lib_threads)
+            logger.debug(_log_memory_status(f"pre-metric {ref_alias} {n_points_raw}pts"))
 
             with dask.config.set(scheduler='synchronous'):
                 results = list_metrics[0].compute(
@@ -1159,7 +1486,7 @@ def compute_metric(
             # results = {}
             results = {}
             # ── Re-cap thread pools before metric computation (grid path) ──
-            _cap_worker_threads(1)
+            _cap_worker_threads(_c_lib_threads)
 
             # Context manager for the loop
             with dask.config.set(scheduler='synchronous'):
@@ -1304,6 +1631,7 @@ def compute_metric(
             "ref_alias": ref_alias,
             "result": None,
             "error": repr(exc),
+            "error_traceback": traceback.format_exc(),
         }
 
     finally:
@@ -1375,6 +1703,7 @@ class Evaluator:
         restart_frequency: int = 1,
         max_p_memory_increase: float = 0.2, # 20% increase default
         max_worker_memory_fraction: float = 0.85,
+        resume: bool = False,
     ):
         """
         Initializes the evaluator.
@@ -1407,6 +1736,8 @@ class Evaluator:
             max_worker_memory_fraction (float, optional): Absolute threshold (fraction of
                 Dask memory_limit) beyond which restart is triggered.
                 Defaults to 0.85 (85%).
+            resume (bool, optional): When True, skip batches whose result file
+                already exists and passes integrity checks.  Defaults to False.
         """
         self.dataset_manager = dataset_manager
         self.dataset_processor = dataset_processor
@@ -1415,6 +1746,7 @@ class Evaluator:
         self.dask_cfgs_by_dataset = dask_cfgs_by_dataset or {}
         self.reduce_precision = reduce_precision
         self.surface_only = surface_only
+        self.resume = resume
         self.restart_workers_per_batch = restart_workers_per_batch
         self.restart_frequency = restart_frequency
         self.max_p_memory_increase = max_p_memory_increase
@@ -1424,6 +1756,7 @@ class Evaluator:
         self.results_dir = results_dir
         # Track the current cluster sizing so we know when to reconfigure.
         self._current_cluster_ref: Optional[str] = None
+        self._workers_initialized: bool = False
 
         (
             self.ref_managers,
@@ -1448,10 +1781,14 @@ class Evaluator:
         if self._current_cluster_ref == ref_alias:
             return  # already configured for this dataset
 
+        _first_call = not self._workers_initialized
+
         desired = self.dask_cfgs_by_dataset.get(ref_alias)
         if not desired:
             # No per-dataset override -> keep current cluster as-is.
             self._current_cluster_ref = ref_alias
+            if _first_call:
+                self._init_workers()
             return
 
         # Read desired sizing.
@@ -1479,6 +1816,8 @@ class Evaluator:
                 ):
                     # Already matches -> nothing to do.
                     self._current_cluster_ref = ref_alias
+                    if _first_call:
+                        self._init_workers()
                     return
             except Exception:
                 pass  # cannot query -> proceed with reconfiguration
@@ -1489,29 +1828,69 @@ class Evaluator:
         )
 
         # Tear down existing cluster.
-        # Silence distributed.worker during teardown: workers that still have
-        # an in-flight heartbeat will log a CommClosedError when the scheduler
-        # stream is closed.  This is expected and non-fatal.
-        # We suppress the logger *and* wait a short time after close() so that
-        # any in-flight async heartbeats complete while the logger is still
-        # silenced.
+        # During teardown a race exists in Dask's Tornado layer: the
+        # scheduler's TCP listener is stopped while workers still have
+        # in-flight connections, producing harmless ValueError /
+        # CommClosedError / "Scheduler unaware" warnings.  We suppress
+        # them by temporarily raising the level of the `distributed`
+        # logger (which has propagate=False and its own StreamHandler).
         import logging as _logging
         import time as _time
-        _dist_logger = _logging.getLogger("distributed")
-        _dist_worker_logger = _logging.getLogger("distributed.worker")
-        _dist_level = _dist_logger.level
-        _dist_worker_level = _dist_worker_logger.level
-        _dist_logger.setLevel(_logging.CRITICAL)
-        _dist_worker_logger.setLevel(_logging.CRITICAL)
+
+        # Raise the `distributed` tree to ERROR during teardown so
+        # INFO/WARNING chatter ("Connection closed", "Scheduler was
+        # unaware") is silenced.  Also cover `tornado.application`.
+        _loggers_to_hush = {
+            n: _logging.getLogger(n)
+            for n in ("distributed", "distributed.core",
+                      "distributed.worker", "tornado.application")
+        }
+        _saved_levels = {n: lg.level for n, lg in _loggers_to_hush.items()}
+        # Also raise handler levels (Dask adds a StreamHandler on `distributed`).
+        _saved_handler_levels: list = []
+        for lg in _loggers_to_hush.values():
+            lg.setLevel(_logging.ERROR)
+            for h in lg.handlers:
+                _saved_handler_levels.append((h, h.level))
+                h.setLevel(_logging.ERROR)
+
         try:
-            self.dataset_processor.close()
-            # Give in-flight heartbeat RPCs time to fail silently.
+            _client = getattr(self.dataset_processor, "client", None)
+            _cluster = getattr(self.dataset_processor, "cluster", None)
+            # 1. Retire workers — waits for in-flight tasks to finish.
+            if _client is not None:
+                try:
+                    _client.retire_workers(close_workers=True)
+                except Exception:
+                    pass
+            # 2. Close the Client (disconnects from scheduler).
+            if _client is not None:
+                try:
+                    _client.close()
+                except Exception:
+                    pass
+            # 3. Brief pause to let the Tornado event loop drain.
             _time.sleep(1.0)
+            # 4. Close the Cluster (stops scheduler + nannies).
+            if _cluster is not None:
+                try:
+                    _cluster.close()
+                except Exception:
+                    pass
+            # Mark as already closed so DatasetProcessor.close()
+            # doesn't try again.
+            self.dataset_processor.client = None
+            self.dataset_processor.cluster = None
+            self.dataset_processor._owns_client = False
+            # 5. Final drain for any residual async callbacks.
+            _time.sleep(0.5)
         except Exception:
             pass
         finally:
-            _dist_logger.setLevel(_dist_level)
-            _dist_worker_logger.setLevel(_dist_worker_level)
+            for n, lg in _loggers_to_hush.items():
+                lg.setLevel(_saved_levels[n])
+            for h, lvl in _saved_handler_levels:
+                h.setLevel(lvl)
 
         # Create a fresh DatasetProcessor.
         self.dataset_processor = DatasetProcessor(
@@ -1528,13 +1907,31 @@ class Evaluator:
         except Exception:
             pass
 
+        # Configure mallopt + thread caps on the new workers.
+        try:
+            self.dataset_processor.client.run(_worker_full_cleanup)
+        except Exception:
+            pass
+
+        self._workers_initialized = True
         self._current_cluster_ref = ref_alias
         # Reset baseline memory after cluster rebuild.
         self.baseline_memory = None
+        logger.debug(_log_memory_status(f"post-reconfig-{ref_alias}"))
         logger.debug(
             f"Dask cluster reconfigured for '{ref_alias}': "
             f"dashboard={getattr(self.dataset_processor.client, 'dashboard_link', 'N/A')}"
         )
+
+    def _init_workers(self) -> None:
+        """Run _worker_full_cleanup on all workers (mallopt, thread caps, env vars)."""
+        _client = getattr(self.dataset_processor, "client", None)
+        if _client is not None:
+            try:
+                _client.run(_worker_full_cleanup)
+            except Exception:
+                pass
+        self._workers_initialized = True
 
     def log_cluster_memory_usage(self, batch_idx: int):
         """Log memory usage of each Dask worker."""
@@ -1605,6 +2002,43 @@ class Evaluator:
         except Exception:
             return 0.0
 
+    @staticmethod
+    def _validate_batch_file(
+        batch_file: str, expected_items: int,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Check if a batch result file exists and is valid.
+
+        Validates:
+        1. File exists
+        2. Gzip decompression succeeds
+        3. JSON parsing succeeds and yields a list
+        4. Item count matches expected batch size
+
+        Returns the parsed list of result dicts if valid, None otherwise.
+        """
+        if not os.path.isfile(batch_file):
+            return None
+        try:
+            with gzip.open(batch_file, "rt", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, list):
+                logger.warning(f"Checkpoint invalid (not a list): {batch_file}")
+                return None
+            if len(data) != expected_items:
+                logger.warning(
+                    f"Checkpoint invalid (expected {expected_items} items, "
+                    f"got {len(data)}): {batch_file}"
+                )
+                return None
+            return data
+        except (gzip.BadGzipFile, json.JSONDecodeError, OSError, EOFError) as exc:
+            logger.warning(f"Checkpoint corrupt ({exc!r}): {batch_file}")
+            try:
+                os.remove(batch_file)
+            except OSError:
+                pass
+            return None
+
     def evaluate(self) -> List[Dict[str, Any]]:
         """
         Evaluates metrics on dataloader data for each reference.
@@ -1639,13 +2073,34 @@ class Evaluator:
         # error.  Deleting the directory at the start of each run forces a
         # clean rebuild from the full set of observation files.
         _obs_shared_root = _results_path / "obs_batch_shared"
-        if _obs_shared_root.exists():
+        if _obs_shared_root.exists() and not self.resume:
             import shutil as _shutil_obs
             try:
                 _shutil_obs.rmtree(_obs_shared_root, ignore_errors=True)
                 logger.debug(f"Purged stale obs_batch_shared cache: {_obs_shared_root}")
             except Exception:
                 pass
+        elif _obs_shared_root.exists() and self.resume:
+            # Resume: keep complete shared zarrs, but clean up incomplete
+            # batch dirs (mini-zarrs without a merged batch_shared.zarr).
+            import shutil as _shutil_obs
+            _cleaned_incomplete = 0
+            for _ds_dir in _obs_shared_root.iterdir():
+                if not _ds_dir.is_dir():
+                    continue
+                for _batch_dir in _ds_dir.iterdir():
+                    if not _batch_dir.is_dir():
+                        continue
+                    if not (_batch_dir / "batch_shared.zarr").is_dir():
+                        _shutil_obs.rmtree(_batch_dir, ignore_errors=True)
+                        _cleaned_incomplete += 1
+            if _cleaned_incomplete:
+                logger.info(
+                    f"Resume: cleaned {_cleaned_incomplete} incomplete "
+                    f"obs_batch_shared dir(s)."
+                )
+            else:
+                logger.debug("Resume mode: keeping obs_batch_shared cache.")
 
         try:
             # ── Pre-materialise batches to know total count ───────────
@@ -1661,12 +2116,135 @@ class Evaluator:
                 f"{sum(len(b) for b in _all_batches)} total tasks"
             )
 
+            # ── Resume: count how many batches already have valid checkpoints
+            if self.resume:
+                pred_alias_for_count = self.dataloader.pred_alias
+                _n_cached = 0
+                for _bi, _bb in enumerate(_all_batches):
+                    _bf = os.path.join(
+                        self.results_dir or ".",
+                        f"results_{pred_alias_for_count}_batch_{_bi}.json.gz",
+                    )
+                    if os.path.isfile(_bf):
+                        _n_cached += 1
+                if _n_cached:
+                    logger.info(
+                        f"Resume: {_n_cached}/{_total_batches} batch checkpoint(s) "
+                        f"found — will validate and skip completed batches."
+                    )
+                else:
+                    logger.info("Resume: no existing checkpoints found, starting fresh.")
+
             _prev_ref_alias: Optional[str] = None
             _ref_aliases_ordered: List[str] = list(
                 dict.fromkeys(
                     b[0].get("ref_alias") for b in _all_batches if b and b[0].get("ref_alias")  # type: ignore[misc]
                 )
             )
+
+            # ── Per-ref and global tracking for summary ───────────────
+            _ref_stats: Dict[str, Dict[str, Any]] = {}
+            _eval_t0 = time.time()
+
+            def _dw(s: str) -> int:
+                """Display width of *s*, counting known wide symbols as 2.
+
+                Most terminals render East Asian 'W'/'F' chars as 2 cells.
+                Ambiguous ('A') chars are generally 1 cell in Western locales,
+                except a few symbols (◆, ★, ✔, …) that many terminals and
+                mono fonts render wide. We maintain an explicit set so that
+                box-drawing chars (also 'A') are correctly counted as 1.
+                """
+                import unicodedata as _ud
+                # Symbols observed to render as 2 cells in common terminals.
+                _WIDE = frozenset()  # emoji (🏆📊⏳…) are already 'W'/'F'
+                w = 0
+                for ch in s:
+                    eaw = _ud.east_asian_width(ch)
+                    if eaw in ('W', 'F') or ch in _WIDE:
+                        w += 2
+                    else:
+                        w += 1
+                return w
+
+            def _pad(text: str, width: int) -> str:
+                """Left-align *text* in *width* display columns."""
+                return text + ' ' * max(0, width - _dw(text))
+
+            _ANSI_RE = __import__("re").compile(r"\033\[[0-9;]*m")
+
+            def _pad_ansi(text: str, width: int) -> str:
+                """Like _pad but ignores ANSI escape sequences when measuring width."""
+                visible = _ANSI_RE.sub("", text)
+                return text + ' ' * max(0, width - _dw(visible))
+
+            def _print_ref_summary(alias: str) -> None:
+                """Print a summary box for a completed reference dataset."""
+                st = _ref_stats.get(alias)
+                if st is None:
+                    return
+                elapsed = time.time() - st["t0"]
+                st["elapsed"] = elapsed  # freeze for global summary
+                m, s = divmod(int(elapsed), 60)
+                h, m = divmod(m, 60)
+                _w = 60
+                _M = "\033[1;35m"   # bold magenta – summary box
+                _Y = "\033[33m"     # yellow – warnings
+                _R0 = "\033[0m"     # reset
+
+                n_ok    = st["n_tasks"] - st["n_errors"] - st["n_skipped"]
+                n_pts   = st["n_points"]
+                n_err   = st["n_errors"]
+                n_skip  = st["n_skipped"]
+
+                # Period covered (earliest → latest valid_time seen)
+                _t_min  = st.get("t_min")
+                _t_max  = st.get("t_max")
+                if _t_min and _t_max:
+                    try:
+                        _ts_min = str(pd.Timestamp(_t_min).date())
+                        _ts_max = str(pd.Timestamp(_t_max).date())
+                        _period = f"{_ts_min}  →  {_ts_max}"
+                    except Exception:
+                        _period = f"{_t_min}  →  {_t_max}"
+                else:
+                    _period = "N/A"
+
+                # Human-readable point count
+                if n_pts >= 1_000_000:
+                    _pts_str = f"{n_pts / 1_000_000:.2f} M"
+                elif n_pts >= 1_000:
+                    _pts_str = f"{n_pts / 1_000:.1f} K"
+                else:
+                    _pts_str = str(n_pts)
+
+                _err_color  = _Y if n_err  > 0 else ""
+                _skip_color = _Y if n_skip > 0 else ""
+
+                _n_batches   = st["n_batches"]
+                _n_tasks     = st["n_tasks"]
+                _line_period  = f"   Period            : {_period}"
+                _line_points  = f"   Obs points        : {_pts_str}"
+                _line_batches = f"   Batches           : {_n_batches}"
+                _line_tasks   = f"   Tasks  ok / total : {n_ok} / {_n_tasks}"
+                _line_elapsed = f"   Elapsed           : {h}h {m:02d}m {s:02d}s"
+                _sep_w        = "─" * _w
+
+                print(f"    {_M}┌{_sep_w}┐{_R0}")
+                print(f"    {_M}│{_pad('  ✔  Summary  ─  ' + str(alias).upper(), _w)}│{_R0}")
+                print(f"    {_M}│{_sep_w}│{_R0}")
+                print(f"    {_M}│{_pad(_line_period,  _w)}│{_R0}")
+                print(f"    {_M}│{_pad(_line_points,  _w)}│{_R0}")
+                print(f"    {_M}│{_pad(_line_batches, _w)}│{_R0}")
+                print(f"    {_M}│{_pad(_line_tasks,   _w)}│{_R0}")
+                if n_err > 0:
+                    _line_err = f"   {_err_color}Errors             : {n_err}{_R0}"
+                    print(f"    {_M}│{_pad_ansi(_line_err, _w)}│{_R0}")
+                if n_skip > 0:
+                    _line_skip = f"   {_skip_color}Skipped (no data)  : {n_skip}{_R0}"
+                    print(f"    {_M}│{_pad_ansi(_line_skip, _w)}│{_R0}")
+                print(f"    {_M}│{_pad(_line_elapsed, _w)}│{_R0}")
+                print(f"    {_M}└{_sep_w}┘{_R0}")
 
             for batch_idx, batch in enumerate(_all_batches):
                 _next_raw = _all_batches[batch_idx + 1] if batch_idx + 1 < _total_batches else None
@@ -1676,6 +2254,10 @@ class Evaluator:
 
                 # Print the reference banner the first time a new reference is encountered.
                 if ref_alias != _prev_ref_alias:
+                    # ── Summary for the PREVIOUS ref dataset ──────────
+                    if _prev_ref_alias is not None:
+                        _print_ref_summary(_prev_ref_alias)
+
                     _n_ref_total = len(_ref_aliases_ordered)
                     _n_ref_current = (
                         _ref_aliases_ordered.index(ref_alias) + 1
@@ -1683,12 +2265,25 @@ class Evaluator:
                         else "?"
                     )
                     _sep_ref = "─" * 60
-                    print(f"    ┌{_sep_ref}┐")
-                    print(
-                        f"    │  ◆  Reference dataset ({_n_ref_current}/{_n_ref_total}) :  {str(ref_alias).upper():<28}│"  # noqa: E501
-                    )
-                    print(f"    └{_sep_ref}┘")
+                    _C = "\033[1;36m"   # bold cyan – reference dataset
+                    _R0 = "\033[0m"
+                    print(f"    {_C}┌{_sep_ref}┐{_R0}")
+                    _ref_line = f"  ◆  Reference dataset ({_n_ref_current}/{_n_ref_total}) :  {str(ref_alias).upper()}"
+                    print(f"    {_C}│{_pad(_ref_line, 60)}│{_R0}")
+                    print(f"    {_C}└{_sep_ref}┘{_R0}")
                     _prev_ref_alias = ref_alias
+
+                    # ── Initialise tracking for the new ref ───────────
+                    _ref_stats[ref_alias] = {
+                        "t0": time.time(),
+                        "n_batches": 0,
+                        "n_tasks": 0,
+                        "n_points": 0,
+                        "n_errors": 0,
+                        "n_skipped": 0,
+                        "t_min": None,
+                        "t_max": None,
+                    }
 
                 # ── Reconfigure cluster if this ref dataset needs
                 #    different sizing (workers / threads / memory) ──
@@ -1708,12 +2303,63 @@ class Evaluator:
                 # Build look-ahead context for the NEXT batch (if any).
                 # _evaluate_batch will launch the background download during
                 # its as_completed loop (workers busy -> driver has spare CPU).
+                # Look-ahead depth: download preds for the next N batches
+                # (not just N+1) so fast compute never stalls on S3.
                 _la_next = None
                 if _next_raw is not None:
+                    # Gather pred URLs from the next few batches (same ref only)
+                    _LA_DEPTH = 3  # look ahead up to 3 batches
+                    _la_extra_batches: List[List[Dict[str, Any]]] = []
+                    for _lk in range(1, _LA_DEPTH + 1):
+                        _fi = batch_idx + _lk
+                        if _fi < _total_batches:
+                            _fb = _all_batches[_fi]
+                            if _fb and _fb[0].get("ref_alias") == ref_alias:
+                                _la_extra_batches.append(_fb)
+                            else:
+                                break  # different ref → stop
+                        else:
+                            break
                     _la_next = {
                         'batch': _next_raw,
                         'ref_alias': _next_raw[0].get("ref_alias") if _next_raw else None,
+                        'extra_pred_batches': _la_extra_batches[1:] if len(_la_extra_batches) > 1 else [],
                     }
+
+                # ── Resume: try to load existing batch checkpoint ─────
+                batch_file = os.path.join(
+                    self.results_dir or ".", f"results_{pred_alias}_batch_{batch_idx}.json.gz"
+                )
+                if self.resume:
+                    _cached = self._validate_batch_file(batch_file, expected_items=len(batch))
+                    if _cached is not None:
+                        logger.info(
+                            f"Resume: skipping batch {batch_idx}/{_total_batches} "
+                            f"({ref_alias}, {len(batch)} tasks) — checkpoint valid"
+                        )
+                        serial_results = _cached
+                        # Accumulate stats from the cached results
+                        if ref_alias in _ref_stats:
+                            _st = _ref_stats[ref_alias]
+                            _st["n_batches"] += 1
+                            _st["n_tasks"] += len(batch)
+                            for _r in serial_results:
+                                if not isinstance(_r, dict):
+                                    continue
+                                if _r.get("error"):
+                                    _st["n_errors"] += 1
+                                elif _r.get("n_points", 0) == 0:
+                                    _st["n_skipped"] += 1
+                                else:
+                                    _st["n_points"] += int(_r.get("n_points", 0))
+                                _vt = _r.get("valid_time")
+                                if _vt is not None:
+                                    if _st["t_min"] is None or _vt < _st["t_min"]:
+                                        _st["t_min"] = _vt
+                                    if _st["t_max"] is None or _vt > _st["t_max"]:
+                                        _st["t_max"] = _vt
+                        del _cached, serial_results
+                        continue
 
                 batch_results = self._evaluate_batch(
                     batch, pred_alias, ref_alias,  # type: ignore[arg-type]
@@ -1732,17 +2378,75 @@ class Evaluator:
                     if res is not None
                 ]
 
-                # Save batch by batch
-                batch_file = os.path.join(
-                    self.results_dir or ".", f"results_{pred_alias}_batch_{batch_idx}.json"
-                )
-                with open(batch_file, "w") as f:
-                    json.dump(serial_results, f, indent=2, ensure_ascii=False)
+                # Save batch by batch (gzip: 15-20× smaller than plain JSON)
+                with gzip.open(batch_file, "wt", encoding="utf-8", compresslevel=6) as f:
+                    json.dump(serial_results, f, separators=(',', ':'), ensure_ascii=False)
+
+                # ── Accumulate per-ref stats ─────────────────────────
+                if ref_alias in _ref_stats:
+                    _st = _ref_stats[ref_alias]
+                    _st["n_batches"] += 1
+                    _st["n_tasks"] += len(batch)
+                    for _r in serial_results:
+                        if not isinstance(_r, dict):
+                            continue
+                        if _r.get("error"):
+                            _st["n_errors"] += 1
+                        elif _r.get("n_points", 0) == 0:
+                            _st["n_skipped"] += 1
+                        else:
+                            _st["n_points"] += int(_r.get("n_points", 0))
+                        # Track period via valid_time
+                        _vt = _r.get("valid_time")
+                        if _vt is not None:
+                            if _st["t_min"] is None or _vt < _st["t_min"]:
+                                _st["t_min"] = _vt
+                            if _st["t_max"] is None or _vt > _st["t_max"]:
+                                _st["t_max"] = _vt
 
                 # CRITICAL: Explicit cleanup
                 del batch_results
                 del serial_results
                 gc.collect()
+
+                # ── Disk cleanup: purge prefetch caches from this batch ───
+                # Prefetched observation zarrs are no longer needed once the
+                # batch results are saved.  Cleaning them prevents unbounded
+                # disk growth (SWOT obs alone can reach 100+ GB over a full
+                # year).  Prediction zarrs may be reused across batches for
+                # different reference datasets, so we only clean them when
+                # switching to a new reference dataset.
+                #
+                # IMPORTANT: do NOT clean obs cache when the next batch uses
+                # the same ref_alias — the look-ahead thread has already
+                # pre-downloaded observation files into the same directory.
+                # Cleaning here would wipe them, forcing a full re-download.
+                import shutil as _sh_cleanup
+                _results_dir = self.results_dir or "."
+                _next_ref = (
+                    _all_batches[batch_idx + 1][0].get("ref_alias")
+                    if batch_idx + 1 < _total_batches
+                    else None
+                )
+                # Only clean observation prefetch when switching to a
+                # different reference dataset (or on the last batch).
+                if _next_ref != ref_alias:
+                    for _obs_sub in ("obs_prefetch_cache", "ref_prefetch_cache"):
+                        _cache_alias_path = os.path.join(_results_dir, _obs_sub, str(ref_alias))
+                        if os.path.isdir(_cache_alias_path):
+                            try:
+                                _sh_cleanup.rmtree(_cache_alias_path, ignore_errors=True)
+                            except Exception:
+                                pass
+                # Clean pred prefetch when switching reference (next batch
+                # will have different time windows needing different preds)
+                if _next_ref != ref_alias:
+                    _pred_path = os.path.join(_results_dir, "pred_prefetch_cache")
+                    if os.path.isdir(_pred_path):
+                        try:
+                            _sh_cleanup.rmtree(_pred_path, ignore_errors=True)
+                        except Exception:
+                            pass
 
                 # ── Memory-triggered worker restart ───────────────────────
                 # Two criteria (either one triggers a restart):
@@ -1801,7 +2505,9 @@ class Evaluator:
                                     "distributed"
                                 ).setLevel(_log_restart.CRITICAL)
                                 try:
-                                    _client.restart()
+                                    _client.restart_workers(
+                                        list(_client.scheduler_info()["workers"]),
+                                    )
                                 except Exception as _exc_restart:
                                     logger.warning(
                                         f"Worker restart failed: {_exc_restart!r}"
@@ -1813,6 +2519,39 @@ class Evaluator:
                                 # Reset baseline after the cluster is clean.
                                 self.baseline_memory = None
                                 gc.collect()
+
+            # ── Summary for the LAST ref dataset ─────────────────
+            if _prev_ref_alias is not None:
+                _print_ref_summary(_prev_ref_alias)
+
+            # ── Global evaluation summary ─────────────────────────────
+            _eval_elapsed = time.time() - _eval_t0
+            _em, _es = divmod(int(_eval_elapsed), 60)
+            _eh, _em = divmod(_em, 60)
+            _w = 60
+            _G = "\033[1;32m"   # bold green – global summary
+            _R0 = "\033[0m"
+            print(f"\n    {_G}╔{'═' * _w}╗{_R0}")
+            print(f"    {_G}║{_pad('  ★  GLOBAL EVALUATION SUMMARY', _w)}║{_R0}")
+            print(f"    {_G}╠{'═' * _w}╣{_R0}")
+            _total_batches_done = 0
+            _total_tasks_done = 0
+            for _ra in _ref_aliases_ordered:
+                _rs = _ref_stats.get(_ra)
+                if _rs is None:
+                    continue
+                _re = _rs.get("elapsed", time.time() - _rs["t0"])
+                # Use stored elapsed for completed refs, live for last
+                _rm, _rss = divmod(int(_re), 60)
+                _rh, _rm = divmod(_rm, 60)
+                _line = f"   {str(_ra).upper():<20} {_rs['n_batches']:>4} batches  {_rs['n_tasks']:>5} tasks  {_rh}h {_rm:02d}m {_rss:02d}s"
+                print(f"    {_G}║{_pad(_line, _w)}║{_R0}")
+                _total_batches_done += _rs["n_batches"]
+                _total_tasks_done += _rs["n_tasks"]
+            print(f"    {_G}╠{'═' * _w}╣{_R0}")
+            _totline = f"   {'TOTAL':<20} {_total_batches_done:>4} batches  {_total_tasks_done:>5} tasks  {_eh}h {_em:02d}m {_es:02d}s"
+            print(f"    {_G}║{_pad(_totline, _w)}║{_R0}")
+            print(f"    {_G}╚{'═' * _w}╝{_R0}\n")
 
             # Cleanup scattered data
             self.scattered_argo_indexes.clear()
@@ -1926,6 +2665,24 @@ class Evaluator:
             batch_t0 = time.time()
             num_tasks = len(batch)
 
+            # ── Inject C-library thread cap into each entry ──────────────
+            # Datasets that override nthreads_per_worker (reducing Dask
+            # concurrency) can reclaim the freed CPU slots for internal
+            # C-library parallelism (pyinterp, BLAS, OpenMP).
+            # The YAML key ``c_lib_threads`` (default 1) controls how many
+            # threads each C-library call may use inside a single task.
+            # Workers read this from entry["_c_lib_threads"] and pass it
+            # to _cap_worker_threads().
+            _ds_cfg = self.dask_cfgs_by_dataset.get(ref_alias, {})
+            _c_lib_threads = int(_ds_cfg.get("c_lib_threads", 1))
+            _download_workers: Optional[int] = (
+                int(_ds_cfg["download_workers"])
+                if _ds_cfg.get("download_workers") is not None
+                else None
+            )
+            for _entry in batch:
+                _entry["_c_lib_threads"] = _c_lib_threads
+
             # ── Throttle observation batches to prevent CPU oversubscription ──
             # Observation datasets (satellite) trigger heavy
             # CPU-bound interpolation (pyinterp) on each worker.  Submitting
@@ -1936,9 +2693,10 @@ class Evaluator:
             # sub-batches so that at most *max_concurrent_obs* tasks run in
             # parallel, leaving headroom for the OS and driver.
             is_obs_batch = batch and batch[0].get("ref_is_observation", False)
-            # All tasks run with _cap_worker_threads(1) so internal C++
-            # libraries (pyinterp, BLAS, Blosc) create only 1 thread each.
-            # No need to throttle concurrency below n_workers.
+            # C-library threads are controlled per-dataset via the YAML key
+            # ``c_lib_threads`` (default 1), injected into each entry above.
+            # Datasets that reduce nthreads_per_worker can raise c_lib_threads
+            # to reclaim the freed CPU slots for pyinterp/BLAS parallelism.
             # max_concurrent_obs = num_tasks
 
             # with threads_per_worker set to 1, C libraries are capped to 1.
@@ -2112,6 +2870,19 @@ class Evaluator:
             #   • No concurrent S3 requests from multiple workers
             #   • Workers open local files -> fast, no bandwidth contention
             _obs_path_map: Dict[str, str] = _la_data.get('obs_map', {}) if _la_data else {}
+            # Validate look-ahead obs paths still exist on disk (the
+            # inter-batch cleanup may have deleted them).
+            if _obs_path_map:
+                _stale = [
+                    k for k, v in _obs_path_map.items()
+                    if not os.path.isdir(v)
+                ]
+                if _stale:
+                    logger.debug(
+                        f"Look-ahead obs cache: {len(_stale)}/{len(_obs_path_map)} "
+                        f"paths stale (cleaned between batches) — re-downloading"
+                    )
+                    _obs_path_map = {}
             _obs_prefetch = (
                 is_obs_batch
                 and ref_alias != "argo_profiles"
@@ -2179,6 +2950,7 @@ class Evaluator:
                                 cache_dir=_obs_cache_dir,
                                 fs=_ref_mgr.params.fs,  # type: ignore[union-attr]
                                 ref_alias=str(ref_alias),
+                                max_download_workers=_download_workers,
                             )
                             # Inject mapping into every batch entry
                             for _entry in batch:
@@ -2206,9 +2978,6 @@ class Evaluator:
                 if not batch:
                     return
                 if is_obs_batch:
-                    return
-
-                if os.environ.get("DCTOOLS_ENABLE_REF_PREFETCH", "1") not in ("1", "true", "True"):
                     return
 
                 _ref_protocol = getattr(ref_connection_params, "protocol", None)
@@ -2297,14 +3066,18 @@ class Evaluator:
                             f"Reference prefetch failed for {_fname}: {_exc_rf!r}"
                         )
 
-                # Be conservative: reference stores can be large.
-                _N_REF_DL = min(2, len(_unique_ref_paths))
+                # Reference zarrs (GLORYS) can be large; use per-dataset
+                # download_workers if configured, otherwise default to 4.
+                if _download_workers is not None and _download_workers > 0:
+                    _N_REF_DL = min(_download_workers, len(_unique_ref_paths))
+                else:
+                    _N_REF_DL = min(4, len(_unique_ref_paths))
                 with _RefPool(max_workers=_N_REF_DL) as _rp:
                     list(_rp.map(_dl_one_ref, _unique_ref_paths))
 
                 if _ref_result:
                     logger.debug(
-                        f"Reference prefetch ({ref_alias}): "
+                        f"Reference prefetch ({ref_alias}, {_N_REF_DL} threads): "
                         f"{_counters['dl']} downloaded, "
                         f"{_counters['hit']} cached "
                         f"({len(_unique_ref_paths)} unique files)"
@@ -2374,6 +3147,72 @@ class Evaluator:
                         _local_zarr
                     ):
                         if _is_valid_local_dataset_cache(_local_zarr):
+                            # ── Cache hit: ensure time_chunk == 1 ────────────
+                            # Zarrs cached before the rechunking fix (or written
+                            # with native time_chunk > 1) force workers to read
+                            # ALL lead times when selecting a single timestep —
+                            # e.g. 10 × 21 depths × 5 vars × float64 ≈ 8 GB per
+                            # task vs ~400 MB with time_chunk=1.  Rechunk once,
+                            # in-place, so all future cache hits are correct.
+                            try:
+                                _probe = xr.open_zarr(
+                                    _local_zarr, consolidated=True, chunks={}
+                                )
+                                _needs_rchk = False
+                                if _probe.sizes.get("time", 1) > 1:
+                                    for _vv in _probe.data_vars:
+                                        if "time" in _probe[_vv].dims:
+                                            _dc = dict(zip(
+                                                _probe[_vv].dims,
+                                                _probe[_vv].data.chunks,
+                                            ))
+                                            if _dc.get("time", (1,))[0] > 1:
+                                                _needs_rchk = True
+                                                break
+                                _probe.close()
+                                del _probe
+                            except Exception:
+                                _needs_rchk = False
+
+                            if _needs_rchk:
+                                logger.debug(
+                                    f"Rechunking cached pred zarr "
+                                    f"(time→1): {_fname}"
+                                )
+                                _rchk_path = _local_zarr + ".rechunking"
+                                try:
+                                    if os.path.isdir(_rchk_path):
+                                        _sh_pred.rmtree(
+                                            _rchk_path, ignore_errors=True
+                                        )
+                                    with dask.config.set(
+                                        scheduler="synchronous"
+                                    ):
+                                        _ds_hit = xr.open_zarr(
+                                            _local_zarr, chunks={}
+                                        ).drop_encoding()
+                                        _ds_hit.chunk({"time": 1}).to_zarr(
+                                            _rchk_path,
+                                            mode="w",
+                                            consolidated=True,
+                                            safe_chunks=False,
+                                        )
+                                        _ds_hit.close()
+                                        del _ds_hit
+                                    _sh_pred.rmtree(
+                                        _local_zarr, ignore_errors=True
+                                    )
+                                    os.rename(_rchk_path, _local_zarr)
+                                except Exception as _exc_rchk:
+                                    logger.warning(
+                                        f"Cache rechunk failed for "
+                                        f"{_fname}: {_exc_rchk!r}"
+                                    )
+                                    if os.path.isdir(_rchk_path):
+                                        _sh_pred.rmtree(
+                                            _rchk_path, ignore_errors=True
+                                        )
+
                             with _pred_lock:
                                 _pred_result[_rp] = _local_zarr
                                 _counters["hit"] += 1
@@ -2410,20 +3249,52 @@ class Evaluator:
                                 _tmp_zarr,
                                 recursive=True,
                             )
+                            # Rechunk the time dimension to 1 so each worker
+                            # reads only its needed timestep instead of the
+                            # full native time chunk (e.g. 10 days at once).
+                            # Uses synchronous scheduler: one depth chunk at a
+                            # time --> driver RAM stays bounded.
+                            _tmp_zarr_rchk = _tmp_zarr + ".rechunked"
+                            with dask.config.set(
+                                scheduler="synchronous"
+                            ):
+                                _ds_rchk = xr.open_zarr(
+                                    _tmp_zarr, chunks={}
+                                ).drop_encoding()
+                                if _ds_rchk.sizes.get("time", 1) > 1:
+                                    _ds_rchk.chunk({"time": 1}).to_zarr(
+                                        _tmp_zarr_rchk,
+                                        mode="w",
+                                        consolidated=True,
+                                        safe_chunks=False,
+                                    )
+                                    _ds_rchk.close()
+                                    del _ds_rchk
+                                    _sh_pred.rmtree(
+                                        _tmp_zarr,
+                                        ignore_errors=True,
+                                    )
+                                    os.rename(_tmp_zarr_rchk, _tmp_zarr)
+                                else:
+                                    _ds_rchk.close()
+                                    del _ds_rchk
                         else:
                             import xarray as _xr_prefetch
+                            # Rechunk time=1 and stream lazily to avoid a
+                            # full-zarr .compute() spike in driver RAM.
                             with dask.config.set(
                                 scheduler="synchronous"
                             ):
                                 _ds_pf = _xr_prefetch.open_zarr(
                                     _rp, chunks={}
+                                ).drop_encoding()
+                                if _ds_pf.sizes.get("time", 1) > 1:
+                                    _ds_pf = _ds_pf.chunk({"time": 1})
+                                _ds_pf.to_zarr(
+                                    _tmp_zarr, mode="w",
+                                    consolidated=True,
+                                    safe_chunks=False,
                                 )
-                                _ds_pf = _ds_pf.compute()
-                            _ds_pf.to_zarr(
-                                _tmp_zarr, mode="w",
-                                consolidated=True,
-                            )
-                            _ds_pf.close()
                             del _ds_pf
 
                         if os.path.isdir(_local_zarr):
@@ -2440,7 +3311,16 @@ class Evaluator:
                             f"{_fname}: {_exc_pf!r}"
                         )
 
-                _N_PRED_DL = min(4, len(_unique_pred_paths))
+                _pred_ds_cfg = self.dask_cfgs_by_dataset.get(pred_alias, {})
+                _pred_dl_workers: Optional[int] = (
+                    int(_pred_ds_cfg["download_workers"])
+                    if _pred_ds_cfg.get("download_workers") is not None
+                    else None
+                )
+                if _pred_dl_workers is not None and _pred_dl_workers > 0:
+                    _N_PRED_DL = min(_pred_dl_workers, len(_unique_pred_paths))
+                else:
+                    _N_PRED_DL = min(4, len(_unique_pred_paths))
                 with _PredPool(max_workers=_N_PRED_DL) as _pp:
                     list(_pp.map(_dl_one_pred, _unique_pred_paths))
 
@@ -2462,7 +3342,6 @@ class Evaluator:
             _sample_ref = batch[0].get("ref_data") if batch else None
             _need_ref_prefetch = (
                 (not is_obs_batch)
-                and (os.environ.get("DCTOOLS_ENABLE_REF_PREFETCH", "1") in ("1", "true", "True"))
                 and (_ref_protocol in ("wasabi", "s3"))
                 and isinstance(_sample_ref, str)
                 and _sample_ref.endswith(".zarr")
@@ -2564,6 +3443,7 @@ class Evaluator:
                             n_points_dim=_n_pts_dim,
                             output_zarr_dir=_shared_zarr_dir,
                             eval_variables=_eval_vars,
+                            max_workers=_N,
                         )
 
                         if _shared_obs_zarr:
@@ -2593,9 +3473,9 @@ class Evaluator:
 
             _t_prefetch_total = time.time() - _phase_t0
             logger.debug(
-                f"Prefetch done in {_t_prefetch_total:.1f}s "
+                f"Prefetch detail: {_t_prefetch_total:.1f}s "
                 f"(obs_dl={_t_obs_dl:.1f}s  obs_prep={_t_obs_prep:.1f}s  "
-                f"ref_dl={_t_ref_dl:.1f}s  pred_dl={_t_pred_dl:.1f}s) — dispatching {num_tasks} tasks"  # noqa: E501
+                f"ref_dl={_t_ref_dl:.1f}s  pred_dl={_t_pred_dl:.1f}s)"
             )
 
             # Apply reference path remapping (from current batch prefetch)
@@ -2617,6 +3497,19 @@ class Evaluator:
 
             # Apply look-ahead prediction paths (downloaded during previous batch)
             _la_pred_map = _la_data.get('pred_map', {}) if _la_data else {}
+            # Validate look-ahead pred paths still exist on disk
+            if _la_pred_map:
+                _stale_pred = [
+                    k for k, v in _la_pred_map.items()
+                    if not os.path.isdir(v)
+                ]
+                if _stale_pred:
+                    logger.debug(
+                        f"Look-ahead pred cache: {len(_stale_pred)}/{len(_la_pred_map)} "
+                        f"paths stale — discarding"
+                    )
+                    for _sp in _stale_pred:
+                        del _la_pred_map[_sp]
             if _la_pred_map:
                 for _entry in batch:
                     _pd = _entry.get("pred_data")
@@ -2632,27 +3525,26 @@ class Evaluator:
             _Y = "\033[1;33m"   # bold yellow – reference dataset name
             _D = "\033[0;90m"   # dim grey   – separator
             _R = "\033[0m"      # reset
+
+            # ── Compact date range from batch tasks ───────────────────
+            _date_tag = ""
+            _raw_dates = [e.get("forecast_reference_time") for e in batch if e.get("forecast_reference_time") is not None]
+            if _raw_dates:
+                _d0, _d1 = min(_raw_dates), max(_raw_dates)
+                _fmt = "%d/%m/%y"  # compact: DD/MM/YY
+                try:
+                    _d0s = _d0.strftime(_fmt)
+                    _d1s = _d1.strftime(_fmt)
+                except Exception:
+                    _d0s = str(_d0)[:5]
+                    _d1s = str(_d1)[:5]
+                _date_tag = f" {_D}[{_d0s}-->{_d1s}]{_R}"
+
             _batch_desc = (
                 f"{_C}⏳ Batch N°{_batch_idx+1}/{_total_batches}{_R}"
                 f" {_D}│{_R} "
                 f"{_Y}📊 {ref_alias}{_R}"
-            )
-            _overall_bar = tqdm(
-                total=num_tasks,
-                desc=_batch_desc,
-                leave=True,
-                unit="task",
-                dynamic_ncols=True,
-                colour="#36b3a0",
-                file=_sys_bars.stderr,
-                bar_format=(
-                    "{desc}: {percentage:3.0f}%|{bar}| "
-                    "{n_fmt}/{total_fmt} [{elapsed}<{remaining}]{postfix}"
-                ),
-            )
-
-            logger.debug(
-                f"{ref_alias}: {num_tasks} tasks on {_N} workers"
+                f"{_date_tag}"
             )
 
             # ── Observation scheduling: submit heavy windows first ──
@@ -2725,9 +3617,25 @@ class Evaluator:
                 _ac.add(_f)
                 _next += 1
 
-            logger.debug(
-                f"{ref_alias}: {_n_seed}/{num_tasks} tasks submitted to "
-                f"{_N} workers — waiting for first result…"
+            logger.info(
+                f"{ref_alias}: {_n_seed}/{num_tasks} tasks → {_N} workers "
+                f"(prefetch {_t_prefetch_total:.1f}s)"
+            )
+
+            # Create the progress bar AFTER all logger.info messages so
+            # they don't interrupt the bar rendering.
+            _overall_bar = tqdm(
+                total=num_tasks,
+                desc=_batch_desc,
+                leave=True,
+                unit="task",
+                dynamic_ncols=True,
+                colour="#36b3a0",
+                file=_sys_bars.stderr,
+                bar_format=(
+                    "{desc}: {percentage:3.0f}%|{bar}| "
+                    "{n_fmt}/{total_fmt} [{elapsed}<{remaining}]{postfix}"
+                ),
             )
             if _overall_bar is not None:
                 _overall_bar.set_postfix_str("workers busy…")
@@ -2744,6 +3652,13 @@ class Evaluator:
                 _la_is_obs = (
                     _la_batch
                     and _la_batch[0].get("ref_is_observation", False)
+                )
+                # Look-ahead may target a different dataset → fetch its own download_workers
+                _la_ds_cfg = self.dask_cfgs_by_dataset.get(_la_ref_alias, {})
+                _la_download_workers: Optional[int] = (
+                    int(_la_ds_cfg["download_workers"])
+                    if _la_ds_cfg.get("download_workers") is not None
+                    else None
                 )
 
                 def _do_lookahead():
@@ -2808,11 +3723,20 @@ class Evaluator:
                                         / "obs_prefetch_cache"
                                         / str(_la_ref_alias)
                                     )
-                                    logger.debug(
+                                    # Use tqdm.write() so the progress
+                                    # bar is not disrupted by this message
+                                    # (runs in a background thread).
+                                    _la_msg = (
                                         f"Look-ahead: downloading "
                                         f"{len(_la_uniq)} obs files "
                                         f"for {_la_ref_alias}"
                                     )
+                                    if _overall_bar is not None:
+                                        _overall_bar.write(
+                                            f"  ℹ️  {_la_msg}"
+                                        )
+                                    else:
+                                        logger.info(_la_msg)
                                     _la_obs_map = (
                                         prefetch_obs_files_to_local(
                                             remote_paths=_la_uniq,
@@ -2821,6 +3745,7 @@ class Evaluator:
                                             ref_alias=(
                                                 f"LA:{_la_ref_alias}"
                                             ),
+                                            max_download_workers=_la_download_workers,
                                         )
                                     )
                                     if _la_obs_map:
@@ -2877,8 +3802,26 @@ class Evaluator:
                                         )
                                     )
                                 )
+                                # Also collect pred URLs from deeper
+                                # look-ahead batches (N+2, N+3, …)
+                                _la_extra = _lookahead_next.get(
+                                    'extra_pred_batches', []
+                                )
+                                _la_seen = set(_la_upreds)
+                                for _xb in _la_extra:
+                                    for _xe in _xb:
+                                        _xp = _xe.get("pred_data")
+                                        if (
+                                            isinstance(_xp, str)
+                                            and _xp not in _la_seen
+                                        ):
+                                            _la_upreds.append(_xp)
+                                            _la_seen.add(_xp)
                                 _la_pred_map: Dict[str, str] = {}
-                                for _rp in _la_upreds:
+                                import threading as _la_dl_thr
+                                _la_pred_lock = _la_dl_thr.Lock()
+
+                                def _la_dl_one(_rp):
                                     _fn = _PfLA2(_rp).name
                                     _lz = os.path.join(
                                         _la_pred_cache, _fn
@@ -2887,8 +3830,9 @@ class Evaluator:
                                         os.path.isdir(_lz)
                                         and os.listdir(_lz)
                                     ):
-                                        _la_pred_map[_rp] = _lz
-                                        continue
+                                        with _la_pred_lock:
+                                            _la_pred_map[_rp] = _lz
+                                        return
                                     try:
                                         _s3k = _rp
                                         if (
@@ -2905,7 +3849,8 @@ class Evaluator:
                                         ):
                                             _s3k = _s3k[5:]
                                         _tmpz = (
-                                            _lz + ".downloading.la"
+                                            _lz
+                                            + f".downloading.la.{_la_dl_thr.current_thread().ident}"
                                         )
                                         if os.path.isdir(_tmpz):
                                             _sh_la.rmtree(
@@ -2918,15 +3863,73 @@ class Evaluator:
                                                 _tmpz,
                                                 recursive=True,
                                             )
-                                        if os.path.isdir(_lz):
+                                            # Rechunk time→1 (same as
+                                            # prefetch) so workers never
+                                            # see time_chunk>1 data.
+                                            try:
+                                                _la_ds = xr.open_zarr(
+                                                    _tmpz, chunks={}
+                                                ).drop_encoding()
+                                                if _la_ds.sizes.get(
+                                                    "time", 1
+                                                ) > 1:
+                                                    _la_rchk = (
+                                                        _tmpz
+                                                        + ".rechunked"
+                                                    )
+                                                    with dask.config.set(
+                                                        scheduler="synchronous"
+                                                    ):
+                                                        _la_ds.chunk(
+                                                            {"time": 1}
+                                                        ).to_zarr(
+                                                            _la_rchk,
+                                                            mode="w",
+                                                            consolidated=True,
+                                                            safe_chunks=False,
+                                                        )
+                                                    _la_ds.close()
+                                                    del _la_ds
+                                                    _sh_la.rmtree(
+                                                        _tmpz,
+                                                        ignore_errors=True,
+                                                    )
+                                                    os.rename(
+                                                        _la_rchk, _tmpz
+                                                    )
+                                                else:
+                                                    _la_ds.close()
+                                                    del _la_ds
+                                            except Exception:
+                                                pass
+                                        # Skip overwrite if the zarr
+                                        # was already placed by the
+                                        # current batch's prefetch.
+                                        if (
+                                            os.path.isdir(_lz)
+                                            and os.listdir(_lz)
+                                        ):
                                             _sh_la.rmtree(
-                                                _lz,
+                                                _tmpz,
                                                 ignore_errors=True,
                                             )
-                                        os.rename(_tmpz, _lz)
-                                        _la_pred_map[_rp] = _lz
+                                            with _la_pred_lock:
+                                                _la_pred_map[_rp] = _lz
+                                        else:
+                                            os.rename(_tmpz, _lz)
+                                            with _la_pred_lock:
+                                                _la_pred_map[_rp] = _lz
                                     except Exception:
                                         pass
+
+                                from concurrent.futures import (
+                                    ThreadPoolExecutor as _LaPool,
+                                )
+                                _la_n = min(4, len(_la_upreds))
+                                with _LaPool(max_workers=_la_n) as _lp:
+                                    list(_lp.map(
+                                        _la_dl_one, _la_upreds
+                                    ))
                                 if _la_pred_map:
                                     _result['pred_map'] = _la_pred_map
 
@@ -2970,6 +3973,8 @@ class Evaluator:
             _last_progress: list = [time.time()]
             # After this many seconds with zero new completions -> cancel all.
             _STALL_TIMEOUT = 1200  # 20 minutes — SWOT per-worker preprocessing can be slow
+            _MAX_WATCHDOG_RETRIES = 3  # max times a single task can be resubmitted after watchdog cancel
+            _retry_count: Dict[int, int] = {}  # task_index -> number of watchdog retries so far
 
             # Log the inevitable "tail" once: when pending tasks <= execution slots,
             # the cluster cannot keep all slots busy (under-subscription).
@@ -3014,7 +4019,7 @@ class Evaluator:
                     _pending = max(num_tasks - _n_collected, 0)
                     pct = 100.0 * (_n_collected / num_tasks) if num_tasks else 0.0
                     _overall_bar.set_postfix_str(
-                        f"{pct:.1f}% done, {_elapsed:.0f}s elapsed"
+                        f"{_elapsed:.0f}s elapsed"
                     )
 
                     if (not _tail_logged[0]) and _pending <= _total_slots:
@@ -3030,11 +4035,23 @@ class Evaluator:
                     # ── Watchdog: cancel futures if no progress ──────────
                     _stall_s = time.time() - _last_progress[0]
                     if _stall_s >= _STALL_TIMEOUT and _active:
+                        # Check which tasks are eligible for retry
+                        _retriable = []
+                        _exhausted = []
+                        for _sf, _si in list(_active.items()):
+                            _prev = _retry_count.get(_si, 0)
+                            if _prev < _MAX_WATCHDOG_RETRIES:
+                                _retriable.append((_sf, _si))
+                            else:
+                                _exhausted.append((_sf, _si))
+                        _n_retry = len(_retriable)
+                        _n_exhaust = len(_exhausted)
                         logger.error(
                             f"{ref_alias}: NO task completed in the last "
                             f"{_stall_s:.0f}s — workers appear deadlocked "
                             f"(likely S3/network timeout).  Cancelling "
-                            f"{len(_active)} stuck futures to unblock."
+                            f"{len(_active)} stuck futures "
+                            f"({_n_retry} retriable, {_n_exhaust} exhausted)."
                         )
                         for _stuck_f in list(_active.keys()):
                             try:
@@ -3064,6 +4081,88 @@ class Evaluator:
                     try:
                         _res = _done.result()
                     except Exception as _exc:
+                        # ── Retry cancelled/deadlocked tasks ─────────────
+                        _is_cancel = "CancelledError" in type(_exc).__name__
+                        _prev_retries = _retry_count.get(_idx, 0)
+                        if _is_cancel and _prev_retries < _MAX_WATCHDOG_RETRIES:
+                            _retry_count[_idx] = _prev_retries + 1
+                            logger.warning(
+                                f"Task {_idx} ({ref_alias}) cancelled by watchdog — "
+                                f"resubmitting (attempt {_prev_retries + 2}/{_MAX_WATCHDOG_RETRIES + 1})"
+                            )
+                            # Restart only the worker(s) that were processing
+                            # the stuck futures — NOT the entire cluster.
+                            # _client.restart() kills ALL workers which then
+                            # fail to reconnect within 60 s on large clusters.
+                            try:
+                                _proc = _client.processing()
+                                _stuck_key = _done.key
+                                _stuck_workers = [
+                                    w for w, keys in _proc.items()
+                                    if _stuck_key in keys
+                                ]
+                                if _stuck_workers:
+                                    _result_map = _client.restart_workers(
+                                        _stuck_workers,
+                                        timeout=120,
+                                        raise_for_error=False,
+                                    )
+                                    logger.info(
+                                        f"{ref_alias}: targeted restart of "
+                                        f"{len(_stuck_workers)} worker(s): {_result_map}"
+                                    )
+                                else:
+                                    # Future already cancelled / unassigned
+                                    # — no worker to restart.  Check whether
+                                    # ALL workers are dead; if so, restart the
+                                    # entire cluster so resubmitted tasks can
+                                    # actually be scheduled.
+                                    try:
+                                        _sched_workers = _client.scheduler_info().get("workers", {})
+                                        _live_workers = [
+                                            w for w, info in _sched_workers.items()
+                                            if info.get("status") != "closed"
+                                        ]
+                                    except Exception:
+                                        _live_workers = []
+                                    if not _live_workers:
+                                        logger.warning(
+                                            f"{ref_alias}: ALL workers are dead — "
+                                            f"restarting cluster"
+                                        )
+                                        try:
+                                            _client.restart(timeout=120)
+                                            _client.run(_worker_full_cleanup)
+                                            logger.info(
+                                                f"{ref_alias}: cluster restarted — "
+                                                f"{len(_client.scheduler_info().get('workers', {}))} "
+                                                f"worker(s) alive"
+                                            )
+                                        except Exception as _restart_all_exc:
+                                            logger.error(
+                                                f"{ref_alias}: cluster restart failed: "
+                                                f"{_restart_all_exc!r}"
+                                            )
+                                    else:
+                                        logger.info(
+                                            f"{ref_alias}: stuck task not assigned to "
+                                            f"any worker — skipping restart "
+                                            f"({len(_live_workers)} worker(s) still alive)"
+                                        )
+                            except Exception as _restart_exc:
+                                logger.warning(
+                                    f"{ref_alias}: worker restart failed: "
+                                    f"{_restart_exc!r} — resubmitting anyway"
+                                )
+                            _f_retry = _client.submit(
+                                fn, batch[_idx], retries=1, pure=False
+                            )
+                            _all_futures.append(_f_retry)
+                            _active[_f_retry] = _idx
+                            _submitted_at[_f_retry] = time.monotonic()
+                            _ac.add(_f_retry)
+                            _last_progress[0] = time.time()  # reset stall watchdog
+                            continue  # do NOT count as collected
                         logger.warning(
                             f"Task {_idx} ({ref_alias}) raised: {_exc!r}"
                         )
@@ -3114,13 +4213,23 @@ class Evaluator:
                 _hb_stop.set()
                 _hb_thread.join(timeout=2)
                 try:
+                    _final_elapsed = time.time() - _hb_t0
+                    _overall_bar.set_postfix_str(
+                        f"{_final_elapsed:.0f}s"
+                    )
                     _overall_bar.close()
                 except Exception:
                     pass
 
-            # ── Wait for look-ahead thread (non-blocking if already done) ──
+            # ── Wait for look-ahead thread ─────────────────────────────
+            # The look-ahead downloads + rechunks prediction zarrs to
+            # the same cache directory used by the *next* batch's
+            # prefetch.  If the daemon finishes AFTER the next batch
+            # starts, it can race with the prefetch and overwrite
+            # rechunked zarrs with un-rechunked S3 copies.
+            # Use a generous timeout so the thread can complete.
             if _la_thread is not None:
-                _la_thread.join(timeout=5)
+                _la_thread.join(timeout=300)
 
             # ── Explicit batch cleanup on client/workers ───────────────────
             try:
@@ -3218,7 +4327,7 @@ class Evaluator:
                 total_pts = sum(points)
                 avg_pp = sum(preprocs) / len(preprocs)
                 avg_mt = sum(times) / len(times)
-                logger.debug(
+                logger.info(
                     f"Batch done: {len(batch_results)}/{num_tasks} tasks "
                     f"in {batch_duration:.1f}s | "
                     f"Avg preproc={avg_pp:.1f}s  metrics={avg_mt:.1f}s | "

--- a/dctools/metrics/oceanbench_metrics.py
+++ b/dctools/metrics/oceanbench_metrics.py
@@ -2,6 +2,7 @@
 
 """Wrapper for functions implemented in Mercator's oceanbench library."""
 
+import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -97,40 +98,14 @@ def _compute_spatial_per_bins(
     """Compute spatial-binned RMSE for grid-to-grid datasets.
 
     Returns a dict ``{variable_name: [{"lat_bin": ..., "lon_bin": ..., "rmse": ...}, ...]}``.
+
+    Uses fully-vectorised numpy accumulation (np.bincount) instead of nested
+    Python loops over lat/lon bins, giving ~30–100× speedup for fine
+    bin_resolution values.
     """
     import numpy as np
 
     per_bins: Dict[str, list] = {}
-
-    def _iter_depth_slices(da: xr.DataArray) -> List[tuple[Optional[int], Optional[Dict[str, float]]]]:
-        da = da.squeeze(drop=True)
-        if "depth" not in da.dims:
-            return [(None, None)]
-
-        depth_values = np.asarray(da["depth"].values, dtype=np.float64)
-        if depth_values.ndim != 1 or depth_values.size == 0:
-            return []
-        if depth_values.size == 1:
-            depth = float(depth_values[0])
-            return [(0, {"left": depth, "right": depth, "closed": "right"})]
-
-        return [
-            (
-                depth_index,
-                {
-                    "left": float(depth_values[depth_index]),
-                    "right": float(depth_values[depth_index + 1]),
-                    "closed": "right",
-                },
-            )
-            for depth_index in range(depth_values.size - 1)
-        ]
-
-    # Determine variables to process
-    var_names = [v for v in eval_variables if v in pred_ds.data_vars and v in ref_ds.data_vars]
-    if not var_names:
-        # Fallback: use common data vars
-        var_names = [v for v in pred_ds.data_vars if v in ref_ds.data_vars]
 
     # Select first time step if present (per_bins is per-timestep already)
     def _squeeze_time(ds: xr.Dataset) -> xr.Dataset:
@@ -148,9 +123,24 @@ def _compute_spatial_per_bins(
     if lat_coord is None or lon_coord is None:
         return {}
 
-    # Build bin edges
+    # Build bin edges and pre-compute per-grid-point 2D flat bin index.
+    # combined_idx[i*nlon + j] = which (lat_bin, lon_bin) cell point (i,j) falls into.
     lat_bins = np.arange(-90, 90 + bin_resolution, bin_resolution)
     lon_bins = np.arange(-180, 180 + bin_resolution, bin_resolution)
+    n_lat_bins = len(lat_bins) - 1
+    n_lon_bins = len(lon_bins) - 1
+    n_bins_total = n_lat_bins * n_lon_bins
+
+    lat_idx = np.clip(np.digitize(lat_coord, lat_bins) - 1, 0, n_lat_bins - 1)  # (nlat,)
+    lon_idx = np.clip(np.digitize(lon_coord, lon_bins) - 1, 0, n_lon_bins - 1)  # (nlon,)
+    # Broadcast to 2D and flatten: shape (nlat * nlon,)
+    combined_idx = (lat_idx[:, None] * n_lon_bins + lon_idx[None, :]).ravel()
+
+    # Determine variables to process
+    var_names = [v for v in eval_variables if v in pred_ds.data_vars and v in ref_ds.data_vars]
+    if not var_names:
+        # Fallback: use common data vars
+        var_names = [v for v in pred_ds.data_vars if v in ref_ds.data_vars]
 
     for var in var_names:
         try:
@@ -162,72 +152,97 @@ def _compute_spatial_per_bins(
         if set(pred_da.dims) != set(ref_da.dims):
             continue
 
-        depth_slices = _iter_depth_slices(pred_da)
-        if not depth_slices:
-            continue
-
-        bins_list = []
-        for depth_index, depth_bin in depth_slices:
-            if depth_index is None:
-                pred_slice = pred_da
-                ref_slice = ref_da
-            else:
-                if "depth" not in ref_da.dims or ref_da.sizes.get("depth", 0) <= depth_index:
-                    continue
-
-                pred_slice = pred_da.isel(depth=depth_index)
-                ref_slice = ref_da.isel(depth=depth_index)
-
-            try:
-                pred_slice = pred_slice.transpose("lat", "lon")
-                ref_slice = ref_slice.transpose("lat", "lon")
-            except Exception:
+        # Determine depth slices to iterate
+        has_depth_dim = "depth" in pred_da.dims
+        if has_depth_dim:
+            depth_values = np.asarray(pred_da["depth"].values, dtype=np.float64)
+            n_depths = int(depth_values.size)
+            if n_depths == 0:
                 continue
+            # Emit intervals [d_i, d_{i+1}) for each consecutive depth pair
+            if n_depths == 1:
+                depth_indices = [0]
+                def _depth_bin(idx: int) -> Dict[str, Any]:
+                    d = float(depth_values[idx])
+                    return {"left": d, "right": d, "closed": "right"}
+            else:
+                depth_indices = list(range(n_depths - 1))
+                def _depth_bin(idx: int) -> Dict[str, Any]:  # type: ignore[misc]
+                    return {
+                        "left": float(depth_values[idx]),
+                        "right": float(depth_values[idx + 1]),
+                        "closed": "right",
+                    }
+        else:
+            depth_indices = [None]
+            depth_values = None
+
+        bins_list: list = []
+
+        for depth_index in depth_indices:
+            if depth_index is not None:
+                if ref_da.sizes.get("depth", 0) <= depth_index:
+                    continue
+                try:
+                    pred_slice = pred_da.isel(depth=depth_index).transpose("lat", "lon")
+                    ref_slice = ref_da.isel(depth=depth_index).transpose("lat", "lon")
+                except Exception:
+                    continue
+                depth_bin: Optional[Dict[str, Any]] = _depth_bin(depth_index)
+            else:
+                try:
+                    pred_slice = pred_da.transpose("lat", "lon")
+                    ref_slice = ref_da.transpose("lat", "lon")
+                except Exception:
+                    continue
+                depth_bin = None
 
             pred_arr = pred_slice.values.astype(np.float64)
             ref_arr = ref_slice.values.astype(np.float64)
             if pred_arr.shape != ref_arr.shape or pred_arr.ndim != 2:
                 continue
 
-            for i in range(len(lat_bins) - 1):
-                lat_mask = (lat_coord >= lat_bins[i]) & (lat_coord < lat_bins[i + 1])
-                if not lat_mask.any():
-                    continue
-                for j in range(len(lon_bins) - 1):
-                    lon_mask = (lon_coord >= lon_bins[j]) & (lon_coord < lon_bins[j + 1])
-                    if not lon_mask.any():
-                        continue
+            # ── Vectorised accumulation ──────────────────────────────────────
+            flat_pred = pred_arr.ravel()
+            flat_ref = ref_arr.ravel()
+            valid = ~(np.isnan(flat_pred) | np.isnan(flat_ref))
+            if not valid.any():
+                continue
 
-                    # Extract sub-array for this bin
-                    sub_pred = pred_arr[np.ix_(lat_mask, lon_mask)]
-                    sub_ref = ref_arr[np.ix_(lat_mask, lon_mask)]
+            diff_sq = (flat_pred[valid] - flat_ref[valid]) ** 2
+            valid_idx = combined_idx[valid]
 
-                    # Flatten and mask NaN
-                    sp = sub_pred.ravel()
-                    sr = sub_ref.ravel()
-                    valid = ~(np.isnan(sp) | np.isnan(sr))
-                    n_valid = int(valid.sum())
-                    if n_valid == 0:
-                        continue
+            # np.bincount is O(N) and ~10× faster than np.add.at for dense integer indices
+            counts = np.bincount(valid_idx, minlength=n_bins_total)
+            sum_sq = np.bincount(valid_idx, weights=diff_sq, minlength=n_bins_total)
 
-                    diff = sp[valid] - sr[valid]
-                    rmse_val = float(np.sqrt(np.mean(diff * diff)))
+            # ── Emit one dict per non-empty bin ──────────────────────────────
+            nz_flat = np.flatnonzero(counts)
+            if nz_flat.size == 0:
+                continue
+            nz_lat = nz_flat // n_lon_bins
+            nz_lon = nz_flat % n_lon_bins
+            nz_rmse = np.sqrt(sum_sq[nz_flat] / counts[nz_flat])
+            nz_counts = counts[nz_flat]
 
-                    bin_entry = {
-                        "lat_bin": {
-                            "left": float(lat_bins[i]),
-                            "right": float(lat_bins[i + 1]),
-                        },
-                        "lon_bin": {
-                            "left": float(lon_bins[j]),
-                            "right": float(lon_bins[j + 1]),
-                        },
-                        "rmse": rmse_val,
-                        "count": n_valid,
-                    }
-                    if depth_bin is not None:
-                        bin_entry["depth_bin"] = depth_bin
-                    bins_list.append(bin_entry)
+            for k in range(nz_flat.size):
+                li = int(nz_lat[k])
+                lj = int(nz_lon[k])
+                entry: Dict[str, Any] = {
+                    "lat_bin": {
+                        "left": float(lat_bins[li]),
+                        "right": float(lat_bins[li + 1]),
+                    },
+                    "lon_bin": {
+                        "left": float(lon_bins[lj]),
+                        "right": float(lon_bins[lj + 1]),
+                    },
+                    "rmse": float(nz_rmse[k]),
+                    "count": int(nz_counts[k]),
+                }
+                if depth_bin is not None:
+                    entry["depth_bin"] = depth_bin
+                bins_list.append(entry)
 
         if bins_list:
             per_bins[var] = bins_list
@@ -296,9 +311,28 @@ def _run_class4_with_raw_per_bins(
     variables: List[str],
     matching_type: str = "nearest",
 ) -> Any:
-    """Run Class4 evaluation while preserving raw per_bins for leaderboard maps."""
+    """Run Class4 evaluation while preserving raw per_bins for leaderboard maps.
+
+    Streaming implementation: observation chunks are processed one at a time
+    (via ``xr_to_obs_dataframe(yield_chunks=True)``) to keep peak worker RSS
+    low (~32 MB per chunk instead of several GiB for the full DataFrame).
+    Partial statistics (count, weighted sum of squared/absolute/signed errors)
+    are accumulated per spatial/temporal bin and reconstituted into final
+    metrics at the end.
+    """
     if not _class4_compat_helpers_available():
         raise RuntimeError("Required oceanbench Class4 helpers are not available")
+
+    import gc
+    import ctypes as _ctypes
+
+    try:
+        _libc = _ctypes.CDLL("libc.so.6")
+        _malloc_trim = _libc.malloc_trim
+    except Exception:
+        _malloc_trim = None
+
+
 
     all_scores: Dict[str, pd.DataFrame] = {}
 
@@ -313,57 +347,396 @@ def _run_class4_with_raw_per_bins(
             )
 
         groupby_cols: List[str] = []
-        obs_col = f"{var}_obs"
-        model_col = f"{var}_model"
 
         if matching_type == "nearest":
-            obs_df = oceanbench_class4_module.xr_to_obs_dataframe(
-                obs_da,
-                include_geometry=False,
-            )
-            # Standardize coordinate column names so that apply_binning and
-            # interpolate_model_on_obs can always find "lat" / "lon".
-            # SWOT (and some other observation datasets) expose their position
-            # coordinates as "latitude" / "longitude" rather than the short
-            # aliases expected by the rest of the pipeline.
+            # ── Streaming nearest-neighbour path ──────────────────────
+            # Accumulate partial statistics per bin across observation
+            # chunks so we never hold the full DataFrame in memory.
+            #
+            # MEMORY OPTIMISATION (critical for SWOT):
+            # The previous implementation called interpolate_model_on_obs
+            # for each 500 K-point chunk.  That function round-tripped
+            # through xarray:
+            #   DataFrame → xr.Dataset.from_dataframe → xr.apply_ufunc
+            #   → xr.Dataset → .values → obs_df.copy()
+            # creating ~80 MB of transient allocations per chunk.  Over
+            # 574 chunks (287 M-point SWOT batch), glibc's ptmalloc
+            # retained fragmented pages, accumulating 4-5 GiB of
+            # "unmanaged" memory per worker.
+            #
+            # The new implementation pre-builds a single pyinterp.Grid2D
+            # from the model and calls grid.bivariate() directly on
+            # numpy arrays — zero xarray overhead, zero DataFrame copies.
+            # Peak transient allocation per chunk drops from ~80 MB to
+            # ~12 MB (3 float64 arrays of 500 K points).
+            bin_stats: Dict[Any, Dict[str, float]] = {}
+            _groupby_cols_resolved: Optional[List[str]] = None
+
             _coord_alias_map = {
                 "latitude": "lat", "nav_lat": "lat",
                 "longitude": "lon", "nav_lon": "lon",
             }
-            _rename = {
-                k: v for k, v in _coord_alias_map.items()
-                if k in obs_df.columns and v not in obs_df.columns
+
+            _chunk_count = 0
+
+            # ── Pre-build pyinterp Grid2D from model (once) ──────────
+            # model_da is already an in-memory numpy-backed DataArray
+            # (pred_data was .compute()'d earlier in compute_metric).
+            _grid2d = None
+            try:
+                import pyinterp
+
+                # Find lat/lon dimension names in the model
+                _lat_dim = next(
+                    (d for d in model_da.dims if d in ("latitude", "lat", "nav_lat")),
+                    None,
+                )
+                _lon_dim = next(
+                    (d for d in model_da.dims if d in ("longitude", "lon", "nav_lon")),
+                    None,
+                )
+                if _lat_dim and _lon_dim:
+                    _src_lat = model_da[_lat_dim].values.astype(np.float64)
+                    _src_lon = model_da[_lon_dim].values.astype(np.float64)
+                    _model_vals = np.asarray(model_da.values, dtype=np.float64)
+                    # Remove leading singleton dims (e.g. time=1, depth=1)
+                    _model_vals = _model_vals.squeeze()
+                    # pyinterp Grid2D expects (lon, lat) C-order
+                    if _model_vals.shape == (len(_src_lat), len(_src_lon)):
+                        _model_vals = _model_vals.T  # (lon, lat)
+                    _x_axis = pyinterp.Axis(_src_lon)
+                    _y_axis = pyinterp.Axis(_src_lat)
+                    _grid2d = pyinterp.Grid2D(_x_axis, _y_axis, _model_vals)
+                    del _model_vals  # Grid2D holds its own copy
+                    logger.debug(
+                        f"[perf] Pre-built pyinterp Grid2D for '{var}': "
+                        f"lat={len(_src_lat)} lon={len(_src_lon)}"
+                    )
+            except Exception as _grid_exc:
+                logger.debug(
+                    f"[perf] Cannot pre-build Grid2D: {_grid_exc!r} "
+                    f"— falling back to interpolate_model_on_obs"
+                )
+
+            # ── Direct zarr chunk iterator ─────────────────────────
+            # We bypass oceanbench's xr_to_obs_dataframe generator to
+            # get full control over the memory lifecycle.  The generator
+            # holds a reference to each yielded DataFrame until the
+            # NEXT iteration, which means our malloc_trim(0) runs while
+            # ~48 MB of chunk data is still live.  Over 574 chunks the
+            # un-trimmed pages accumulate to 4+ GiB of "unmanaged"
+            # memory.
+            #
+            # By reading zarr chunks directly → numpy → minimal
+            # DataFrame (for apply_binning only), we ensure that ALL
+            # references are freed before malloc_trim runs.
+            import dask as _dask
+
+            # Detect n_points dimension
+            _n_pts_dim = None
+            for _d in obs_da.dims:
+                if "point" in _d.lower() or "obs" in _d.lower() or _d.startswith("n_"):
+                    _n_pts_dim = _d
+                    break
+            if _n_pts_dim is None and obs_da.ndim == 1:
+                _n_pts_dim = obs_da.dims[0]
+            if _n_pts_dim is None:
+                # Fallback: largest dimension
+                _n_pts_dim = max(obs_da.dims, key=lambda d: obs_da.sizes[d])
+
+            _n_total = obs_da.sizes[_n_pts_dim]
+
+            # Detect coordinate names in the observation dataset
+            _all_coords = set(obs_da.coords) | set(obs_ds.coords)
+            _lat_coord = next(
+                (c for c in _all_coords
+                 if c.lower() in ("lat", "latitude", "nav_lat")),
+                None,
+            )
+            _lon_coord = next(
+                (c for c in _all_coords
+                 if c.lower() in ("lon", "longitude", "nav_lon")),
+                None,
+            )
+            _time_coord = next(
+                (c for c in _all_coords if c.lower() == "time"), None,
+            )
+            _depth_coord = next(
+                (c for c in _all_coords if c.lower() == "depth"), None,
+            )
+
+            # Keep a legacy interp_cache only if we need the fallback
+            interp_cache: Dict = {} if _grid2d is None else {}
+
+            _CHUNK_SZ = 500_000
+            logger.debug(
+                f"[perf] Direct zarr streaming: {_n_total} points, "
+                f"{(_n_total + _CHUNK_SZ - 1) // _CHUNK_SZ} chunks, "
+                f"grid2d={'yes' if _grid2d else 'no'}"
+            )
+
+            for _start in range(0, _n_total, _CHUNK_SZ):
+                _end = min(_start + _CHUNK_SZ, _n_total)
+                _sl = {_n_pts_dim: slice(_start, _end)}
+
+                # Read observation arrays from dask → numpy (one at a time)
+                with _dask.config.set(scheduler="synchronous"):
+                    _val_arr = obs_da.isel(_sl).values.ravel()
+                    _lat_raw = (
+                        obs_ds[_lat_coord].isel(_sl).values.ravel()
+                        if _lat_coord and _lat_coord in obs_ds
+                        else (obs_da.coords[_lat_coord].isel(_sl).values.ravel()
+                              if _lat_coord and _lat_coord in obs_da.coords
+                              else None)
+                    )
+                    _lon_raw = (
+                        obs_ds[_lon_coord].isel(_sl).values.ravel()
+                        if _lon_coord and _lon_coord in obs_ds
+                        else (obs_da.coords[_lon_coord].isel(_sl).values.ravel()
+                              if _lon_coord and _lon_coord in obs_da.coords
+                              else None)
+                    )
+                    _time_raw = (
+                        obs_ds[_time_coord].isel(_sl).values.ravel()
+                        if _time_coord and _time_coord in obs_ds
+                        else (obs_da.coords[_time_coord].isel(_sl).values.ravel()
+                              if _time_coord and _time_coord in obs_da.coords
+                              else None)
+                    )
+
+                if len(_val_arr) == 0:
+                    del _val_arr, _lat_raw, _lon_raw, _time_raw
+                    continue
+
+                # Build minimal DataFrame for apply_binning
+                _data: Dict[str, Any] = {}
+                if _lat_raw is not None:
+                    _data["lat"] = _lat_raw
+                if _lon_raw is not None:
+                    _data["lon"] = _lon_raw
+                if _time_raw is not None:
+                    _data["time"] = _time_raw
+                _data[var] = _val_arr
+                chunk_df = pd.DataFrame(_data)
+                del _data, _val_arr, _lat_raw, _lon_raw, _time_raw
+
+                # Spatial/temporal binning
+                chunk_df, groupby_cols = oceanbench_class4_module.apply_binning(
+                    chunk_df,
+                    getattr(evaluator, "bin_specs", None),
+                )
+                if _groupby_cols_resolved is None:
+                    _groupby_cols_resolved = list(groupby_cols)
+
+                if chunk_df.empty:
+                    continue
+
+                # Resolve variable column name
+                if var not in chunk_df.columns:
+                    for candidate in ("value", "variable"):
+                        if candidate in chunk_df.columns:
+                            chunk_df = chunk_df.rename(columns={candidate: var})
+                            break
+                if var not in chunk_df.columns:
+                    continue
+
+                chunk_df = chunk_df.dropna(subset=[var])
+                if chunk_df.empty:
+                    continue
+
+                obs_col = f"{var}_obs"
+                model_col = f"{var}_model"
+
+                # ── Interpolate model → observation locations ─────────
+                if _grid2d is not None:
+                    # Fast path: direct pyinterp call (no xarray overhead)
+                    _obs_lon = chunk_df["lon"].values.astype(np.float64)
+                    _obs_lat = chunk_df["lat"].values.astype(np.float64)
+                    _interp_vals = pyinterp.bivariate(
+                        _grid2d, _obs_lon, _obs_lat,
+                        interpolator="bilinear",
+                        num_threads=1,
+                    )
+                    # Build minimal arrays for error computation
+                    obs_vals = chunk_df[var].values.astype(np.float64)
+                    mod_vals = _interp_vals
+
+                    # NaN mask (from interpolation boundary or missing obs)
+                    _valid = np.isfinite(obs_vals) & np.isfinite(mod_vals)
+                    if not _valid.all():
+                        obs_vals = obs_vals[_valid]
+                        mod_vals = mod_vals[_valid]
+                        # Need lat for weights and bin cols for grouping
+                        _lat_arr = (
+                            chunk_df["lat"].values[_valid]
+                            if "lat" in chunk_df.columns
+                            else None
+                        )
+                        _bin_df = (
+                            chunk_df[_groupby_cols_resolved].iloc[
+                                np.where(_valid)[0]
+                            ]
+                            if _groupby_cols_resolved
+                            else None
+                        )
+                    else:
+                        _lat_arr = (
+                            chunk_df["lat"].values
+                            if "lat" in chunk_df.columns
+                            else None
+                        )
+                        _bin_df = (
+                            chunk_df[_groupby_cols_resolved]
+                            if _groupby_cols_resolved
+                            else None
+                        )
+                    del _obs_lon, _obs_lat, _interp_vals, _valid
+                else:
+                    # Fallback: original xarray-based interpolation
+                    chunk_df = chunk_df.rename(columns={var: obs_col})
+                    chunk_df = oceanbench_class4_module.interpolate_model_on_obs(
+                        model_da,
+                        chunk_df,
+                        var,
+                        method=getattr(evaluator, "interp_method", "nearest"),
+                        cache=interp_cache,
+                    )
+                    if len(interp_cache) > 2:
+                        interp_cache.clear()
+                    chunk_df = chunk_df.dropna(subset=[obs_col, model_col])
+                    if chunk_df.empty:
+                        del chunk_df
+                        continue
+                    obs_vals = chunk_df[obs_col].values
+                    mod_vals = chunk_df[model_col].values
+                    _lat_arr = (
+                        chunk_df["lat"].values
+                        if "lat" in chunk_df.columns
+                        else None
+                    )
+                    _bin_df = (
+                        chunk_df[_groupby_cols_resolved]
+                        if _groupby_cols_resolved
+                        else None
+                    )
+
+                # ── Free the chunk DataFrame ASAP ─────────────────────
+                del chunk_df
+
+                if len(obs_vals) == 0:
+                    del obs_vals, mod_vals
+                    continue
+
+                diff = mod_vals - obs_vals
+
+                if _lat_arr is not None:
+                    w = np.cos(np.deg2rad(_lat_arr.astype(np.float64)))
+                else:
+                    w = np.ones(len(diff), dtype=np.float64)
+
+                # Accumulate weighted partial stats per bin
+                agg_cols = list(_groupby_cols_resolved) if _groupby_cols_resolved else []
+
+                if agg_cols and _bin_df is not None:
+                    df_agg = _bin_df.copy()
+                    df_agg["w_sq_err"] = w * diff ** 2
+                    df_agg["w_abs_err"] = w * np.abs(diff)
+                    df_agg["w_err"] = w * diff
+                    df_agg["w_sum"] = w
+                    df_agg["count"] = 1.0
+
+                    grouped = df_agg.groupby(
+                        agg_cols, observed=True, dropna=True,
+                    ).sum(numeric_only=True)
+
+                    for name, row in grouped.iterrows():
+                        if name not in bin_stats:
+                            bin_stats[name] = {
+                                "count": 0.0, "w_sum": 0.0,
+                                "w_sq": 0.0, "w_abs": 0.0, "w_err": 0.0,
+                            }
+                        s = bin_stats[name]
+                        s["count"] += row["count"]
+                        s["w_sum"] += row["w_sum"]
+                        s["w_sq"] += row["w_sq_err"]
+                        s["w_abs"] += row["w_abs_err"]
+                        s["w_err"] += row["w_err"]
+
+                    del df_agg, grouped
+                else:
+                    name = "global"
+                    if name not in bin_stats:
+                        bin_stats[name] = {
+                            "count": 0.0, "w_sum": 0.0,
+                            "w_sq": 0.0, "w_abs": 0.0, "w_err": 0.0,
+                        }
+                    s = bin_stats[name]
+                    s["count"] += len(diff)
+                    s["w_sum"] += float(w.sum())
+                    s["w_sq"] += float((w * diff ** 2).sum())
+                    s["w_abs"] += float((w * np.abs(diff)).sum())
+                    s["w_err"] += float((w * diff).sum())
+
+                del obs_vals, mod_vals, diff, w, _lat_arr, _bin_df
+                _chunk_count += 1
+                gc.collect()
+                # Release glibc malloc arenas back to the OS after every
+                # chunk.  malloc_trim(0) is cheap (~1 ms) and essential
+                # to avoid accumulating GiB of "unmanaged memory".
+                if _malloc_trim is not None:
+                    _malloc_trim(0)
+
+            # Clean up
+            del _grid2d
+            if interp_cache:
+                interp_cache.clear()
+            del interp_cache
+
+            # ── Reconstitute metrics from accumulated stats ──────────
+            groupby_cols = _groupby_cols_resolved or []
+            bin_results = []
+            for name, s in bin_stats.items():
+                n = s["count"]
+                ws = s["w_sum"]
+                if n == 0 or ws == 0:
+                    continue
+                res: Dict[str, Any] = {}
+                if groupby_cols:
+                    if len(groupby_cols) == 1:
+                        res[groupby_cols[0]] = name
+                    else:
+                        for i, col in enumerate(groupby_cols):
+                            res[col] = name[i]
+
+                res["rmse"] = float(np.sqrt(s["w_sq"] / ws))
+                res["mse"] = float(s["w_sq"] / ws)
+                res["mae"] = float(s["w_abs"] / ws)
+                res["bias"] = float(s["w_err"] / ws)
+                res["me"] = res["bias"]
+                res["count"] = float(n)
+                bin_results.append(res)
+
+            # Global aggregation
+            global_stats: Dict[str, float] = {}
+            if bin_results:
+                df_res = pd.DataFrame(bin_results)
+                for m in ("rmse", "mse", "mae", "bias", "me"):
+                    if m in df_res.columns:
+                        global_stats[f"{m}_mean"] = float(df_res[m].mean())
+                        global_stats[f"{m}_median"] = float(df_res[m].median())
+                        global_stats[f"{m}_std"] = float(df_res[m].std())
+
+            scores_result: Any = {
+                "per_bins": bin_results,
+                "global": global_stats,
             }
-            if _rename:
-                obs_df = obs_df.rename(columns=_rename)
 
-            obs_df, groupby_cols = oceanbench_class4_module.apply_binning(
-                obs_df,
-                getattr(evaluator, "bin_specs", None),
-            )
-            if obs_df.empty:
-                continue
+            del bin_stats
+            gc.collect()
 
-            if var not in obs_df.columns:
-                for candidate in ("value", "variable"):
-                    if candidate in obs_df.columns:
-                        obs_df = obs_df.rename(columns={candidate: var})
-                        break
-            if var not in obs_df.columns:
-                continue
-
-            obs_df = obs_df.dropna(subset=[var]).copy()
-            if obs_df.empty:
-                continue
-
-            obs_df = obs_df.rename(columns={var: obs_col})
-            final_df = oceanbench_class4_module.interpolate_model_on_obs(
-                model_da,
-                obs_df,
-                var,
-                method=getattr(evaluator, "interp_method", "nearest"),
-            )
         elif matching_type == "superobs":
+            obs_col = f"{var}_obs"
+            model_col = f"{var}_model"
             superobs = oceanbench_class4_module.make_superobs(
                 obs_da,
                 model_da,
@@ -388,28 +761,24 @@ def _run_class4_with_raw_per_bins(
                 model_da,
                 var=var,
             )
+
+            _weight_col: Optional[str] = None
+            if "lat" in final_df.columns:
+                _weight_col = "__cos_lat_weight__"
+                final_df[_weight_col] = np.cos(
+                    np.deg2rad(final_df["lat"].values.astype(np.float64))
+                )
+
+            scores_result = oceanbench_class4_module.compute_scores_xskillscore(
+                df=final_df,
+                y_obs_col=obs_col,
+                y_pred_col=model_col,
+                metrics=getattr(evaluator, "metrics", []),
+                weights=_weight_col,
+                groupby=groupby_cols,
+            )
         else:
             raise ValueError(f"Unknown matching_type: {matching_type}")
-
-        # cos(latitude) area weighting — accounts for the convergence of
-        # meridians so that high-latitude points do not receive the same
-        # weight as equatorial ones in the global RMSD.
-        # Inject as a column so grouped slicing is automatic.
-        _weight_col: Optional[str] = None
-        if "lat" in final_df.columns:
-            _weight_col = "__cos_lat_weight__"
-            final_df[_weight_col] = np.cos(
-                np.deg2rad(final_df["lat"].values.astype(np.float64))
-            )
-
-        scores_result = oceanbench_class4_module.compute_scores_xskillscore(
-            df=final_df,
-            y_obs_col=obs_col,
-            y_pred_col=model_col,
-            metrics=getattr(evaluator, "metrics", []),
-            weights=_weight_col,
-            groupby=groupby_cols,
-        )
 
         if isinstance(scores_result, dict):
             scores_df = pd.DataFrame([scores_result])

--- a/dctools/processing/base.py
+++ b/dctools/processing/base.py
@@ -17,6 +17,7 @@ mutualizing generic helpers:
 
 from __future__ import annotations
 
+import gc
 import gzip
 import json
 import math
@@ -54,10 +55,30 @@ from dctools.metrics.metrics import MetricComputer
 from dctools.metrics.oceanbench_metrics import get_variable_alias
 from dctools.utilities.file_utils import empty_folder
 from dctools.utilities.init_dask import configure_dask_logging, configure_dask_workers_env
-from dctools.utilities.misc_utils import make_serializable, nan_to_none, transform_in_place
+from dctools.utilities.misc_utils import make_serializable, transform_in_place
 
 import dcleaderboard as _dcleaderboard
+from rich import progress as _rich_progress
 warnings.simplefilter("ignore", UserWarning)
+
+# Fast JSON backend: orjson is 5–10× faster than stdlib json for large
+# files. Used in post-processing (batch consolidation + per-bins JSONL).
+try:
+    import orjson as _orjson
+    def _json_loads(s: Any) -> Any:
+        return _orjson.loads(s)
+    def _json_load(fp: Any) -> Any:
+        return _orjson.loads(fp.read())
+    def _json_dumps_compact(obj: Any) -> str:
+        return _orjson.dumps(obj).decode()
+except ImportError:  # graceful degradation if orjson is unavailable
+    _orjson = None  # type: ignore[assignment]
+    def _json_loads(s: Any) -> Any:  # type: ignore[misc]
+        return json.loads(s)
+    def _json_load(fp: Any) -> Any:  # type: ignore[misc]
+        return json.load(fp)
+    def _json_dumps_compact(obj: Any) -> str:  # type: ignore[misc]
+        return json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
 
 
 # Stable short-alias dictionaries for the compact .jsonl.gz format (v2).
@@ -82,8 +103,26 @@ _PB_COORD_ALIASES: Dict[str, str] = {
 }
 _PB_FIELD_SHORT: Dict[str, str] = {v: k for k, v in _PB_FIELD_ALIASES.items()}
 _PB_COORD_SHORT: Dict[str, str] = {v: k for k, v in _PB_COORD_ALIASES.items()}
+_PB_COORD_DP: int = 2   # decimal places for bin boundary coordinates
+_PB_METRIC_DP: int = 6  # decimal places for metric values
+_PB_SKIP: frozenset = frozenset({
+    "lat_bin", "lon_bin", "depth_bin",
+    "count", "n", "n_points", "time_bin",
+})
 
 _GEO_LABEL_PAT = re.compile(r'^(\d+(?:\.\d+)?[SNWEsnwe]|0)-(\d+(?:\.\d+)?[SNWEsnwe]|0)$')
+
+
+def _fmt_elapsed(t0: float) -> str:
+    """Return a human-readable elapsed-time string since *t0* (monotonic)."""
+    s = int(_time.monotonic() - t0)
+    if s < 60:
+        return f"{s}s"
+    m, s = divmod(s, 60)
+    if m < 60:
+        return f"{m}m {s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h {m:02d}m {s:02d}s"
 
 
 def _parse_geo_label(label: str) -> Dict[str, float]:
@@ -109,183 +148,227 @@ def _parse_geo_label(label: str) -> Dict[str, float]:
     m = _GEO_LABEL_PAT.match(label)
     if m:
         return {"left": _side(m.group(1)), "right": _side(m.group(2))}
-    # Interval-notation strings produced by str(pd.Interval), e.g. "(-10.0, -9.0]"
-    m2 = re.match(r'^[\[\(]\s*([+-]?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*[\]\)]$', label)
-    if m2:
-        return {"left": float(m2.group(1)), "right": float(m2.group(2))}
     # Fallback: return zeros rather than raising so the JSONL aggregation
     # can continue; affected bins will aggregate to (0, 0) boundaries.
     logger.warning(f"_parse_geo_label: unrecognised label {label!r}, defaulting to 0")
     return {"left": 0.0, "right": 0.0}
 
 
+def _pb_raw_to_v2_row(
+    ref_alias: str,
+    ref_type: str,
+    lead_time: Any,
+    forecast_reference_time: str,
+    per_bins_raw: Dict,
+) -> Optional[Dict]:
+    """Convert a single raw per-bins item to a v2 columnar row dict.
+
+    Input *per_bins_raw* format (row-based, one dict per bin)::
+
+        {"var": [{"lat_bin": {"left": -90, "right": -86}, "lon_bin": {…},
+                  "rmse": 0.42, …}, …], …}
+
+    Output per_bins format (columnar, short-aliased keys)::
+
+        {"var": {"yl": [-90, …], "yr": [-86, …], "xl": […], "xr": […],
+                 "rmse": [0.42, …], …}, …}
+
+    Bin boundaries are rounded to ``_PB_COORD_DP`` decimal places.
+    Metric values are rounded to ``_PB_METRIC_DP`` decimal places.
+    ``None`` metric values (after :func:`nan_to_none`) are preserved as ``None``.
+    Both the ``{"left", "right"}`` dict format and the oceanbench string-label
+    format (e.g. ``"78S-74S"``) are accepted for coordinate bins.
+
+    Returns ``None`` when *per_bins_raw* is empty or all variables have no bins,
+    so callers can skip writing that row.  Agnostic to which reference datasets
+    are present — works for any combination of gridded and observation refs.
+    """
+    per_bins_out: Dict[str, Dict] = {}
+    for var, bins in per_bins_raw.items():
+        if not bins:
+            continue
+        yl: List = []
+        yr: List = []
+        xl: List = []
+        xr: List = []
+        dl: List = []
+        dr: List = []
+        has_depth = False
+        for b in bins:
+            lb = b["lat_bin"]
+            lob = b["lon_bin"]
+            if isinstance(lb, str):
+                lb = _parse_geo_label(lb)
+            if isinstance(lob, str):
+                lob = _parse_geo_label(lob)
+            yl.append(round(lb["left"], _PB_COORD_DP))
+            yr.append(round(lb["right"], _PB_COORD_DP))
+            xl.append(round(lob["left"], _PB_COORD_DP))
+            xr.append(round(lob["right"], _PB_COORD_DP))
+            if "depth_bin" in b:
+                has_depth = True
+                db = b["depth_bin"]
+                dl.append(round(db["left"], _PB_COORD_DP))
+                dr.append(round(db["right"], _PB_COORD_DP))
+        col: Dict[str, List] = {"yl": yl, "yr": yr, "xl": xl, "xr": xr}
+        if has_depth:
+            col["dl"] = dl
+            col["dr"] = dr
+        all_metrics: set = {k for b in bins for k in b if k not in _PB_SKIP}
+        for metric in sorted(all_metrics):
+            col[metric] = [
+                round(float(b[metric]), _PB_METRIC_DP)
+                if b.get(metric) is not None
+                else None
+                for b in bins
+            ]
+        per_bins_out[var] = col
+    if not per_bins_out:
+        return None
+    return {
+        "ra": ref_alias,
+        "rt": ref_type,
+        "lt": lead_time,
+        "ft": forecast_reference_time,
+        "pb": per_bins_out,
+    }
+
+
+def _read_batch_file(path: str) -> Any:
+    """Read and JSON-parse a batch result file (gzip or plain)."""
+    if path.endswith(".gz"):
+        with gzip.open(path, "rb") as f:
+            return _json_load(f)
+    with open(path, "rb") as f:
+        return _json_load(f)
+
+
+def _prefetch_iter(paths, max_ahead: int = 2):
+    """Yield ``(path, parsed_data)`` with look-ahead parsing in background threads.
+
+    .. deprecated::
+        Replaced by :func:`_iter_batch_items` for the consolidation loop.
+        Kept for backward compatibility.
+
+    Peak extra memory: *max_ahead* × one parsed batch (~500 MB each).
+    """
+    from collections import deque as _deque
+    from concurrent.futures import ThreadPoolExecutor as _TPE
+
+    if not paths:
+        return
+    n_ahead = min(max_ahead, len(paths))
+    with _TPE(max_workers=n_ahead) as pool:
+        buf: _deque = _deque()
+        it = iter(paths)
+        for _ in range(min(n_ahead + 1, len(paths))):
+            p = next(it, None)
+            if p is not None:
+                buf.append((p, pool.submit(_read_batch_file, p)))
+        while buf:
+            p, fut = buf.popleft()
+            nxt = next(it, None)
+            if nxt is not None:
+                buf.append((nxt, pool.submit(_read_batch_file, nxt)))
+            yield p, fut.result()
+
+
+def _iter_batch_items(path: str):
+    """Yield individual items from a batch file (JSON array), one at a time.
+
+    Decompresses the file into a text buffer (~1 GB for large batches) and
+    uses :meth:`json.JSONDecoder.raw_decode` to parse items incrementally.
+    Only **one** parsed item exists in memory at any time (~400 MB for items
+    with large ``per_bins``).
+
+    Peak memory: decompressed text + one parsed item ≈ **1.4 GB** for the
+    largest batches, vs the previous ``_prefetch_iter`` approach that held
+    up to 3 fully-parsed batches ≈ **9–12 GB**.
+    """
+    if path.endswith(".gz"):
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            text = f.read()
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+
+    decoder = json.JSONDecoder()
+    idx = 0
+    n = len(text)
+
+    # Skip to opening '['
+    while idx < n and text[idx] != "[":
+        idx += 1
+    if idx >= n:
+        return
+    idx += 1  # skip '['
+
+    while idx < n:
+        # Skip whitespace and commas between items
+        while idx < n and text[idx] in " \t\n\r,":
+            idx += 1
+        if idx >= n or text[idx] == "]":
+            break
+        item, end = decoder.raw_decode(text, idx)
+        idx = end
+        yield item
+
+
 def _aggregate_per_bins_jsonl(raw_path: str) -> Optional[str]:
-    """Aggregate a raw per-bins JSONL into a compact gzip JSONL (format v2).
+    """Convert a legacy raw per-bins JSONL file to compact gzip JSONL (format v2).
 
-    Reads the raw file produced during batch consolidation, where one line
-    exists per (forecast_reference_time, ref_alias, lead_time), and writes
-    a gzip JSONL where:
+    **Legacy fallback only.**  New evaluations write directly to ``.jsonl.gz`` v2
+    via :func:`_pb_raw_to_v2_row` during consolidation and never produce a raw
+    ``.jsonl`` intermediate file.  This function exists to migrate older ``.jsonl``
+    files produced by previous versions of the pipeline.
 
-    * **First line**: schema header ``{"_v": 2, "f": {…}, "c": {…}}``
-      carrying the alias dictionaries so readers can expand short keys.
-    * One data line per raw entry — the full temporal resolution is preserved.
-    * Per-bins data uses a **columnar** layout (one array per coordinate/
-      metric) to eliminate repeated JSON key overhead (~4x JSON compactness
-      vs per-bin dicts).  Coordinate/field keys use the short aliases from
-      ``_PB_COORD_ALIASES`` / ``_PB_FIELD_ALIASES``.
-    * Bin boundary coordinates are rounded to 2 decimal places to merge
-      entries whose float representations differ only in trailing digits
-      (e.g. Glorys vs Argo depth bin edges for the same nominal depth).
+    Processes one line at a time — O(1) RAM regardless of file size or temporal
+    extent of the evaluation.
 
-    This implementation is **streaming**: it processes one JSONL line at a
-    time, keeping memory usage bounded (~2× the size of the largest single
-    line) regardless of the total file size.
-
-    Returns the path to the new ``.jsonl.gz`` file, or ``None`` if the raw
-    file did not exist or contained no per-bins entries.
+    Returns the path to the new ``.jsonl.gz`` file, or ``None`` if the raw file
+    did not exist or contained no per-bins entries.
     """
     if not os.path.isfile(raw_path):
         return None
 
-    _COORD_DP = 2   # decimal places for bin boundary rounding
-    _METRIC_DP = 6  # decimal places for averaged metric values
-    # Keys that are bin coordinates / counters, not metrics to average.
-    _SKIP = frozenset({
-        "lat_bin", "lon_bin", "depth_bin",
-        "count", "n", "n_points", "time_bin",
-    })
-
-    def _bin_key(b: Dict) -> tuple:
-        """Build a hashable, rounded spatial bin key."""
-        lb = b["lat_bin"]
-        lob = b["lon_bin"]
-        if isinstance(lb, str):
-            lb = _parse_geo_label(lb)
-        if isinstance(lob, str):
-            lob = _parse_geo_label(lob)
-        lat = (round(lb["left"], _COORD_DP),
-               round(lb["right"], _COORD_DP))
-        lon = (round(lob["left"], _COORD_DP),
-               round(lob["right"], _COORD_DP))
-        if "depth_bin" in b:
-            db = b["depth_bin"]
-            if isinstance(db, str):
-                db = _parse_geo_label(db)
-            dep = (round(db["left"], _COORD_DP), round(db["right"], _COORD_DP))
-            return lat + lon + dep
-        return lat + lon
-
-    def _entry_to_columnar(entry: Dict) -> Optional[Dict]:
-        """Convert a single raw entry to the compact columnar row format.
-
-        Returns a dict ready for JSON serialization, or None if no bins.
-        """
-        ref_alias = entry.get("ref_alias", "")
-        lead_time = entry.get("lead_time")
-        ref_type = entry.get("ref_type", "gridded")
-        frt = entry.get("forecast_reference_time", "")
-
-        per_bins_out: Dict[str, Dict] = {}
-        for var, bins in entry.get("per_bins", {}).items():
-            bins_by_key: Dict[tuple, Dict] = {}
-            for b in bins:
-                bk = _bin_key(b)
-                cell = bins_by_key.setdefault(bk, {})
-                for metric, val in b.items():
-                    if metric in _SKIP or val is None:
-                        continue
-                    try:
-                        fval = float(val)
-                    except (TypeError, ValueError):
-                        continue
-                    if math.isnan(fval):
-                        continue
-                    ms = cell.setdefault(metric, [0.0, 0])
-                    ms[0] += fval
-                    ms[1] += 1
-
-            keys = list(bins_by_key.keys())
-            if not keys:
-                continue
-            has_depth = len(keys[0]) == 6
-            col: Dict[str, list] = {
-                "yl": [bk[0] for bk in keys],
-                "yr": [bk[1] for bk in keys],
-                "xl": [bk[2] for bk in keys],
-                "xr": [bk[3] for bk in keys],
-            }
-            if has_depth:
-                col["dl"] = [bk[4] for bk in keys]
-                col["dr"] = [bk[5] for bk in keys]
-
-            all_metrics: set = set()
-            for bk in keys:
-                all_metrics.update(bins_by_key[bk])
-            for metric in sorted(all_metrics):
-                col[metric] = [
-                    round(bins_by_key[bk][metric][0] / bins_by_key[bk][metric][1], _METRIC_DP)
-                    if metric in bins_by_key[bk] and bins_by_key[bk][metric][1] > 0
-                    else None
-                    for bk in keys
-                ]
-            per_bins_out[var] = col
-
-        if not per_bins_out:
-            return None
-
-        return {
-            "ra": ref_alias,
-            "rt": ref_type,
-            "lt": lead_time,
-            "ft": frt,
-            "pb": per_bins_out,
-        }
-
-    # ── Streaming single-pass: process one line at a time ──────────────
     out_path = raw_path + ".gz"
-    n_raw = 0
-    n_written = 0
-
     _schema = json.dumps(
         {"_v": 2, "f": _PB_FIELD_ALIASES, "c": _PB_COORD_ALIASES},
         separators=(",", ":"), ensure_ascii=False,
     )
-
+    n_written = 0
     with open(raw_path, encoding="utf-8") as fh, \
-         gzip.open(out_path, "wt", encoding="utf-8", compresslevel=6) as gz:
+         gzip.open(out_path, "wt", encoding="utf-8", compresslevel=1) as gz:
         gz.write(_schema + "\n")
         for raw_line in fh:
             raw_line = raw_line.strip()
             if not raw_line:
                 continue
-            n_raw += 1
-            entry = json.loads(raw_line)
-            row = _entry_to_columnar(entry)
-            # Free the parsed entry immediately to limit peak memory.
-            del entry
+            entry = _json_loads(raw_line)
+            per_bins_raw = entry.get("per_bins")
+            if not per_bins_raw:
+                continue
+            row = _pb_raw_to_v2_row(
+                ref_alias=entry.get("ref_alias", ""),
+                ref_type=entry.get("ref_type", "gridded"),
+                lead_time=entry.get("lead_time"),
+                forecast_reference_time=entry.get("forecast_reference_time", ""),
+                per_bins_raw=per_bins_raw,
+            )
             if row is not None:
-                gz.write(
-                    json.dumps(row, separators=(",", ":"), ensure_ascii=False)
-                    + "\n"
-                )
+                gz.write(_json_dumps_compact(row) + "\n")
                 n_written += 1
-                del row
-
     if n_written == 0:
-        # Nothing useful was produced — remove the empty gz.
+        logger.debug("  _aggregate_per_bins_jsonl: no entries found in {}", raw_path)
         try:
             os.remove(out_path)
         except OSError:
             pass
-        logger.debug("  _aggregate_per_bins_jsonl: no entries found in {}", raw_path)
         return None
-
-    logger.info(
-        f"  Compacting per-bins: {n_raw} raw entr"
-        f"{'y' if n_raw == 1 else 'ies'} --> {n_written} compacted line"
-        f"{'s' if n_written != 1 else ''}"
+    logger.opt(colors=True).info(
+        f"  Converted per-bins: <b>{n_written}</b> entr"
+        f"{'y' if n_written == 1 else 'ies'}  <dim>→</dim>  <cyan>{out_path}</cyan>"
     )
-
     return out_path
 
 
@@ -372,6 +455,12 @@ class BaseDCEvaluation:
             cfg["threads_per_worker"] = int(threads_per_worker)
         if memory_limit is not None:
             cfg["memory_limit"] = memory_limit
+        # Propagate optional C-library thread cap (pyinterp, BLAS, OpenMP).
+        if "c_lib_threads" in source:
+            cfg["c_lib_threads"] = int(source["c_lib_threads"])
+        # Propagate optional download concurrency cap.
+        if "download_workers" in source:
+            cfg["download_workers"] = int(source["download_workers"])
         return cfg
 
     def _build_dask_cfgs_by_dataset(self) -> Dict[str, Dict[str, Any]]:
@@ -591,7 +680,9 @@ class BaseDCEvaluation:
         if getattr(self, "_startup_summary_logged", False):
             return
 
-        logger.info(f"\n{self._build_eval_summary_banner()}")
+        logger.opt(colors=True).info(
+            f"\n<bold><magenta>{self._build_eval_summary_banner()}</magenta></bold>"
+        )
         self._startup_summary_logged = True
 
     def _log_dask_dashboard_once(self) -> None:
@@ -802,9 +893,7 @@ class BaseDCEvaluation:
                 "dataset_processor": self.dataset_processor,
                 "max_samples": self.args.max_samples,
                 "file_cache": manager.file_cache,
-                "target_depth_values": get_target_depth_values(
-                    self.args, surface=getattr(self, "surface_only", False),
-                ),
+                "target_depth_values": get_target_depth_values(self.args),
                 "filter_values": {
                     "start_time": self.args.start_time,
                     "end_time": self.args.end_time,
@@ -1160,6 +1249,7 @@ class BaseDCEvaluation:
     # ------------------------------------------------------------------
     def run_eval(self) -> None:
         """Run the full evaluation pipeline."""
+        _t0 = _time.monotonic()  # wall-clock start for elapsed-time display
         all_datasets: List[str] = getattr(self, "all_datasets", [])
         dataset_references: Dict[str, Any] = getattr(self, "dataset_references", {})
 
@@ -1177,16 +1267,37 @@ class BaseDCEvaluation:
         evaluators: Dict[str, Any] = {}
         models_results: Dict[str, Any] = {}
 
+        _resume = getattr(self.args, "resume", False)
+
         for alias in dataset_references.keys():
             dataset_json_path = os.path.join(self.results_directory, f"results_{alias}.json")
             results_files_dir = os.path.join(self.args.data_directory, "results_batches")
 
-            if os.path.isdir(results_files_dir):
+            if _resume:
+                # Resume mode: keep existing batch files, only remove stale
+                # final results (they will be re-consolidated at the end).
+                os.makedirs(results_files_dir, exist_ok=True)
+                logger.info("Resume mode: keeping existing batch result files.")
+            elif os.path.isdir(results_files_dir):
                 if os.listdir(results_files_dir):
                     logger.debug("Results dir exists. Removing old results files.")
                     empty_folder(results_files_dir, extension=".json")
+                    # Also remove compressed batch files (.json.gz) left by
+                    # previous runs — empty_folder only matches .json suffix.
+                    for _stale_gz in Path(results_files_dir).glob("*.json.gz"):
+                        _stale_gz.unlink(missing_ok=True)
             else:
                 os.makedirs(results_files_dir, exist_ok=True)
+
+            # Remove stale final results for this alias so a crash mid-run
+            # cannot leave outdated files from a previous evaluation.
+            # (Always removed — they are re-created by consolidation.)
+            _stale_final = os.path.join(self.results_directory, f"results_{alias}.json")
+            _stale_pb = os.path.join(self.results_directory, f"results_{alias}_per_bins.jsonl.gz")
+            for _sf in (_stale_final, _stale_pb):
+                if os.path.isfile(_sf):
+                    logger.debug(f"Removing stale result file: {os.path.basename(_sf)}")
+                    os.remove(_sf)
 
             dataset_manager.build_forecast_index(
                 alias,
@@ -1211,14 +1322,13 @@ class BaseDCEvaluation:
             _n_pred_total = len(dataset_references)
             _n_pred_current = list(dataset_references.keys()).index(alias) + 1
 
-            _sep_pred = "▰" * 68
-            print("")
-            print(f"┌{_sep_pred}┐")
-            print(
-                f"│    ▶  Model to evaluate ({_n_pred_current}/{_n_pred_total}) :  {str(alias).upper():<34}│"  # noqa: E501
+            _inner_model = f"  ▶  Model {_n_pred_current}/{_n_pred_total}  —  {alias.upper()}"
+            _inner_model = f"{_inner_model:<68}"
+            logger.opt(colors=True).info(
+                f"\n<yellow>┌{'─' * 68}┐\n"
+                f"│<bold>{_inner_model}</bold>│\n"
+                f"└{'─' * 68}┘</yellow>"
             )
-            print(f"└{_sep_pred}┘")
-            print("")
 
             for ref_alias in list_references:
                 if ref_alias not in dataset_manager.datasets:
@@ -1317,43 +1427,43 @@ class BaseDCEvaluation:
                 if ref_alias in ref_transforms
             }
 
-            # ── Determine per-reference obs_batch_size ─────────────────
-            # Build a dict {ref_alias: batch_size} so each reference dataset
-            # can have its own batch size.  Per-dataset YAML values take
-            # precedence over the global obs_batch_size.
-            _global_obs_bs = getattr(self.args, "obs_batch_size", None)
-            if _global_obs_bs is not None:
-                _global_obs_bs = int(_global_obs_bs)
-            _obs_batch_sizes: Dict[str, int] = {}
+            # ── Determine obs_batch_size ───────────────────────────────
+            # Look for per-dataset obs_batch_size first, then global, then default.
+            _obs_batch_size = None
             for _ref_alias in effective_references:
                 _ref_src: Dict[str, Any] = next(
                     (s for s in self.args.sources if s.get("dataset") == _ref_alias), {}
                 )
                 if _ref_src.get("obs_batch_size") is not None:
-                    _obs_batch_sizes[_ref_alias] = int(_ref_src["obs_batch_size"])
-                elif _global_obs_bs is not None:
-                    _obs_batch_sizes[_ref_alias] = _global_obs_bs
+                    _obs_batch_size = int(_ref_src["obs_batch_size"])
+                    break
+            if _obs_batch_size is None:
+                _obs_batch_size = getattr(self.args, "obs_batch_size", None)
+                if _obs_batch_size is not None:
+                    _obs_batch_size = int(_obs_batch_size)
 
-            # ── Determine per-reference gridded_batch_size ─────────────
-            # Same approach: per-dataset YAML value --> global fallback.
-            _global_grid_bs = getattr(self.args, "gridded_batch_size", None)
-            if _global_grid_bs is not None:
-                _global_grid_bs = int(_global_grid_bs)
-            _gridded_batch_sizes: Dict[str, int] = {}
+            # ── Determine gridded_batch_size ───────────────────────────
+            # Per-reference gridded_batch_size overrides the global batch_size
+            # for non-observation (gridded) reference datasets such as GLORYS.
+            # A small value (e.g. 6) limits per-batch I/O + RAM pressure.
+            _gridded_batch_size = None
             for _ref_alias in effective_references:
                 _ref_src = next(
                     (s for s in self.args.sources if s.get("dataset") == _ref_alias), {}
                 )
                 if _ref_src.get("gridded_batch_size") is not None:
-                    _gridded_batch_sizes[_ref_alias] = int(_ref_src["gridded_batch_size"])
-                elif _global_grid_bs is not None:
-                    _gridded_batch_sizes[_ref_alias] = _global_grid_bs
+                    _gridded_batch_size = int(_ref_src["gridded_batch_size"])
+                    break
+            if _gridded_batch_size is None:
+                _gridded_batch_size = getattr(self.args, "gridded_batch_size", None)
+                if _gridded_batch_size is not None:
+                    _gridded_batch_size = int(_gridded_batch_size)
 
             dataloaders[alias] = dataset_manager.get_dataloader(
                 pred_alias=alias,
                 ref_aliases=effective_references,
-                obs_batch_size=_obs_batch_sizes or None,
-                gridded_batch_size=_gridded_batch_sizes or None,
+                obs_batch_size=_obs_batch_size,
+                gridded_batch_size=_gridded_batch_size,
                 pred_transform=pred_transform,
                 ref_transforms=ref_transforms,  # type: ignore[arg-type]
                 forecast_mode=forecast_mode,
@@ -1370,11 +1480,11 @@ class BaseDCEvaluation:
                 dask_cfgs_by_dataset=self.dask_cfgs_by_dataset,
                 results_dir=results_files_dir,
                 reduce_precision=getattr(self.args, "reduce_precision", False),
-                surface_only=self.surface_only,
                 restart_workers_per_batch=getattr(self.args, "restart_workers_per_batch", False),
                 restart_frequency=getattr(self.args, "restart_frequency", 1),
                 max_p_memory_increase=getattr(self.args, "max_p_memory_increase", 0.2),
                 max_worker_memory_fraction=getattr(self.args, "max_worker_memory_fraction", 0.85),
+                resume=_resume,
             )
             _n_pred_total = len(dataset_references)
             _n_pred_current = list(dataset_references.keys()).index(alias) + 1
@@ -1395,139 +1505,183 @@ class BaseDCEvaluation:
             except Exception:
                 pass
 
+            # ── Release Dask cluster before post-processing ────────────────
+            # The cluster workers (e.g. 6 × 3 GB = 18 GB) are no longer needed
+            # after all batches are processed.  Shutting down now frees that RAM
+            # for the consolidation and leaderboard pipelines, which run on the
+            # driver only.  Without this, the combined memory pressure (idle
+            # workers + driver post-processing) exceeds available RAM and
+            # triggers SIGKILL (exit code 247).
+            try:
+                self.close()
+                gc.collect()
+                logger.debug("Dask cluster shut down — RAM freed for post-processing.")
+            except Exception as _close_exc:
+                logger.debug(f"Cluster shutdown before post-processing: {_close_exc!r}")
+
             # ── Separator: evaluation done -> post-processing ──────────────
-            _sep_post = "─" * 68
+            _inner_post = f"  📦  POST-PROCESSING  —  {alias.upper()}"
+            _inner_post = f"{_inner_post:<68}"  # pre-pad before markup
             logger.opt(colors=True).info(
-                f"\n┌{_sep_post}┐\n"
-                f"│<bold>{'  📦  POST-PROCESSING RESULTS  —  ' + alias.upper():^67}</bold>│\n"
-                f"└{_sep_post}┘"
+                f"\n<magenta>┌{'─' * 68}┐\n"
+                f"│<bold>{_inner_post}</bold>│\n"
+                f"└{'─' * 68}┘</magenta>  <dim>[+{_fmt_elapsed(_t0)}]</dim>"
             )
 
             # Aggregate batch results and write final JSON.
             try:
-                batch_files = glob(os.path.join(results_files_dir, "results_*_batch_*.json"))
-                results_dict: Dict[str, Any] = {}
+                batch_files = sorted(
+                    glob(os.path.join(results_files_dir, "results_*_batch_*.json"))
+                    + glob(os.path.join(results_files_dir, "results_*_batch_*.json.gz"))
+                )
                 n_errors = 0
+                _total_entries = 0
 
-                logger.info(
-                    f"  ┌ Consolidating {len(batch_files)} batch file(s) "
-                    f"for '{alias}' ..."
+                logger.opt(colors=True).info(
+                    f"  <dim>┌</dim> Consolidating <b>{len(batch_files)}</b> batch file(s)"
+                    f" for <cyan>'{alias}'</cyan> …"
                 )
 
-                # Per-bins are written incrementally as a JSONL file (one
-                # compact JSON object per line) so that the full list is never
-                # held in RAM.  This prevents OOM crashes on large datasets
-                # where an indented JSON dump can reach multiple gigabytes.
-                per_bins_path = os.path.join(
+                # Per-bins are written directly to gzip JSONL (format v2) via
+                # _pb_raw_to_v2_row().  No intermediate raw .jsonl is ever
+                # created: peak RAM is bounded to one batch item regardless of
+                # temporal extent or which reference datasets are evaluated.
+                per_bins_gz_path = os.path.join(
                     self.results_directory,
-                    f"results_{alias}_per_bins.jsonl",
+                    f"results_{alias}_per_bins.jsonl.gz",
                 )
                 _pb_count = 0
-                with open(per_bins_path, "w", encoding="utf-8") as pb_file:
-                    for batch_file in batch_files:
-                        with open(batch_file, "r") as f:
-                            batch_results = json.load(f)
-                        for item in batch_results:
+                _pb_schema = json.dumps(
+                    {"_v": 2, "f": _PB_FIELD_ALIASES, "c": _PB_COORD_ALIASES},
+                    separators=(",", ":"), ensure_ascii=False,
+                )
+
+                # ── Streaming JSON writer ──────────────────────────────────
+                # Items are parsed one at a time from each batch file via
+                # _iter_batch_items() + raw_decode.  Only ONE parsed item
+                # lives in memory at a time (~400 MB for large per_bins
+                # items).  The decompressed text buffer (~1 GB) is the only
+                # other significant allocation per batch file.
+                # Previous approach: _prefetch_iter loaded up to 3 full
+                # batches as Python objects — 9–12 GB peak.
+                _first_item = True
+                with open(dataset_json_path, "w", encoding="utf-8") as json_file, \
+                     gzip.open(per_bins_gz_path, "wt", encoding="utf-8", compresslevel=1) as pb_gz_file:
+                    pb_gz_file.write(_pb_schema + "\n")
+
+                    # Write JSON header
+                    json_file.write("{\n")
+                    json_file.write(f'  "dataset": {json.dumps(alias)},\n')
+                    json_file.write(f'  "results": {{\n')
+                    json_file.write(f'    {json.dumps(alias)}: [\n')
+
+                    for batch_file in _rich_progress.track(
+                        batch_files,
+                        description=f"  [{alias}] consolidating …",
+                        total=len(batch_files),
+                        transient=True,
+                    ):
+                        for item in _iter_batch_items(batch_file):
                             if isinstance(item, dict) and item.get("error"):
                                 n_errors += 1
-                            # Pop per_bins before serialization: keeps the main
-                            # results file flat and leaderboard-compatible.
-                            # Write each entry immediately – no in-RAM list.
+                            # Pop per_bins and convert to v2 columnar format
+                            # immediately.  The per_bins dict (~400 MB) is
+                            # freed as soon as _pb_raw_to_v2_row returns.
                             if isinstance(item, dict) and "per_bins" in item:
                                 _is_obs = item.get(
                                     "ref_is_observation",
                                     item.get("is_class4", False),
                                 )
-                                _pb_entry = {
-                                    "ref_alias": item.get("ref_alias", alias),
-                                    "valid_time": item.get("valid_time"),
-                                    "forecast_reference_time": item.get(
-                                        "forecast_reference_time"
+                                _v2_row = _pb_raw_to_v2_row(
+                                    ref_alias=item.get("ref_alias", alias),
+                                    ref_type="observation" if _is_obs else "gridded",
+                                    lead_time=item.get("lead_time"),
+                                    forecast_reference_time=item.get(
+                                        "forecast_reference_time", ""
                                     ),
-                                    "lead_time": item.get("lead_time"),
-                                    "ref_type": "observation" if _is_obs else "gridded",
-                                    "per_bins": item.pop("per_bins"),
-                                }
-                                # Compact JSON (no indent) -> ~4× smaller than
-                                # the previous indented format.
-                                pb_file.write(
-                                    json.dumps(
-                                        nan_to_none(make_serializable(_pb_entry)),
-                                        separators=(",", ":"),
-                                        ensure_ascii=False,
-                                    )
-                                    + "\n"
+                                    per_bins_raw=transform_in_place(
+                                        transform_in_place(
+                                            item.pop("per_bins"),
+                                            make_serializable,
+                                        ),
+                                        lambda x: None if isinstance(x, float) and x != x else x,
+                                    ),
                                 )
-                                _pb_count += 1
-                        transform_in_place(batch_results, make_serializable)
-                        serializable_result = nan_to_none(batch_results)
-                        results_dict.setdefault(alias, []).extend(serializable_result)
+                                if _v2_row is not None:
+                                    pb_gz_file.write(
+                                        _json_dumps_compact(_v2_row) + "\n"
+                                    )
+                                    _pb_count += 1
 
-                _total_entries = sum(len(v) for v in results_dict.values())
-                logger.info(
-                    f"  │  {_total_entries} result entr{'y' if _total_entries == 1 else 'ies'} "
-                    f"consolidated from {len(batch_files)} batch(es)"
+                            # Serialize and write this item immediately.
+                            # After per_bins pop the item is tiny (~a few KB).
+                            transform_in_place(item, make_serializable)
+                            transform_in_place(
+                                item,
+                                lambda x: None if isinstance(x, float) and x != x else x,
+                            )
+                            if not _first_item:
+                                json_file.write(",\n")
+                            _item_str = json.dumps(
+                                item, indent=2, ensure_ascii=False,
+                            )
+                            json_file.write(
+                                "      "
+                                + _item_str.replace("\n", "\n      ")
+                            )
+                            _first_item = False
+                            _total_entries += 1
+                        # Batch file text buffer freed when generator exhausts.
+                        gc.collect()
+
+                    # Close the results array and object, write metadata.
+                    json_file.write("\n    ]\n  },\n")
+                    _metadata = {
+                        "evaluation_date": pd.Timestamp.now().isoformat(),
+                        "total_entries": _total_entries,
+                        "n_errors": n_errors,
+                        "config": {
+                            "start_time": self.args.start_time,
+                            "end_time": self.args.end_time,
+                            "n_days_forecast": self.args.n_days_forecast,
+                            "n_days_interval": self.args.n_days_interval,
+                        },
+                    }
+                    _meta_str = json.dumps(
+                        _metadata, indent=2, ensure_ascii=False,
+                    )
+                    json_file.write(
+                        '  "metadata": '
+                        + _meta_str.replace("\n", "\n  ")
+                        + "\n}\n"
+                    )
+
+                logger.opt(colors=True).info(
+                    f"  <dim>│</dim>  <b>{_total_entries}</b> result entr"
+                    f"{'y' if _total_entries == 1 else 'ies'} from"
+                    f" <b>{len(batch_files)}</b> batch(es)"
                 )
 
                 if _pb_count == 0:
                     # Nothing was written – remove the empty placeholder file.
                     try:
-                        os.remove(per_bins_path)
+                        os.remove(per_bins_gz_path)
                     except OSError:
                         pass
-                    per_bins_path = None  # type: ignore[assignment]
-                    logger.info("  │  No per-bins spatial data produced for this dataset")
+                    per_bins_gz_path = None  # type: ignore[assignment]
+                    logger.opt(colors=True).info("  <dim>│  No per-bins spatial data produced for this dataset</dim>")
                 else:
-                    logger.info(
-                        f"  │  Per-bins spatial data  ->  {_pb_count} raw entr"
-                        f"{'y' if _pb_count == 1 else 'ies'} written; aggregating …"
+                    gz_bytes = os.path.getsize(per_bins_gz_path)
+                    logger.opt(colors=True).info(
+                        f"  <dim>│</dim>  Per-bins  <dim>→</dim>  <b>{_pb_count}</b> entr"
+                        f"{'y' if _pb_count == 1 else 'ies'} <dim>(v2 columnar, direct)</dim>"
+                        f"  <dim>→</dim>  <b>{gz_bytes / 1e6:.1f} MB</b>"
+                        f"  <cyan>({os.path.basename(per_bins_gz_path)})</cyan>"
                     )
-                    # Compact the raw JSONL (one-per-forecast-time) into a
-                    # pre-aggregated columnar gzip JSONL whose size is bounded
-                    # regardless of the temporal extent of the evaluation.
-                    gz_path = _aggregate_per_bins_jsonl(per_bins_path)
-                    if gz_path is not None:
-                        # Replace raw JSONL with the compact version.
-                        try:
-                            os.remove(per_bins_path)
-                        except OSError:
-                            pass
-                        per_bins_path = gz_path
-                        raw_kb = _pb_count * 40 * 1024  # rough raw estimate
-                        gz_bytes = os.path.getsize(gz_path)
-                        logger.info(
-                            f"  │  Per-bins compacted  ->  "
-                            f"{gz_bytes / 1e6:.1f} MB  "
-                            f"({os.path.basename(gz_path)})"
-                        )
 
-                # ── Write results JSON before checking for errors ──────────
-                # Writing first ensures partial results are never discarded
-                # even when a handful of tasks were cancelled by the watchdog.
-                with open(dataset_json_path, "w") as json_file:
-                    json_file.write("")
-                    json.dump(
-                        {
-                            "dataset": alias,
-                            "results": results_dict,
-                            "metadata": {
-                                "evaluation_date": pd.Timestamp.now().isoformat(),
-                                "total_entries": _total_entries,
-                                "n_errors": n_errors,
-                                "config": {
-                                    "start_time": self.args.start_time,
-                                    "end_time": self.args.end_time,
-                                    "n_days_forecast": self.args.n_days_forecast,
-                                    "n_days_interval": self.args.n_days_interval,
-                                },
-                            },
-                        },
-                        json_file,
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                logger.success(
-                    f"  └  Results saved  ->  {os.path.basename(dataset_json_path)}"
+                logger.opt(colors=True).success(
+                    f"  └  <green>✓</green>  Results saved  <dim>→</dim>"
+                    f"  <cyan><b>{os.path.basename(dataset_json_path)}</b></cyan>"
                 )
 
                 # ── Error threshold check ──────────────────────────────────
@@ -1545,13 +1699,15 @@ class BaseDCEvaluation:
                         f"Results were saved to {os.path.basename(dataset_json_path)}."
                     )
                 if n_errors > 0:
-                    logger.warning(
-                        f"  └  {n_errors} task error(s) tolerated "
-                        f"(max_task_errors={_max_errors}) — results saved."
+                    logger.opt(colors=True).warning(
+                        f"  └  <yellow>⚠  {n_errors} task error(s) tolerated</yellow>"
+                        f" (max_task_errors={_max_errors}) — results saved."
                     )
 
             except Exception as exc:
-                logger.error(f"  └  [ERROR] Failed to write JSON results: {exc}")
+                logger.opt(colors=True).error(
+                    f"  <red>└  ✗  Failed to write JSON results:</red>  {exc}"
+                )
                 raise
 
         dataset_manager.file_cache.clear()
@@ -1561,11 +1717,12 @@ class BaseDCEvaluation:
         # ══════════════════════════════════════════════════════════════════
         # waiting 1s for the final log messages to flush before printing the leaderboard header
         _time.sleep(1)
-        _sep_lb = "═" * 68
+        _inner_lb = f"  🏆  LEADERBOARD GENERATION"
+        _inner_lb = f"{_inner_lb:^68}"  # pre-pad before markup
         logger.opt(colors=True).info(
-            f"\n╔{_sep_lb}╗\n"
-            f"║<bold>{'  🏆  LEADERBOARD GENERATION':^67}</bold>║\n"
-            f"╚{_sep_lb}╝"
+            f"\n<green>╔{'═' * 68}╗\n"
+            f"║<bold>{_inner_lb}</bold>║\n"
+            f"╚{'═' * 68}╝</green>  <dim>[+{_fmt_elapsed(_t0)}]</dim>"
         )
 
         if not models_results:
@@ -1700,11 +1857,35 @@ class BaseDCEvaluation:
                 f"  Persisted {len(_copied)} file(s) to {_local_lb_dir} for future leaderboards"
             )
 
-            logger.info(" Rendering leaderboard site ...")
+            logger.opt(colors=True).info("  <dim>◎</dim>  Rendering leaderboard site …")
+            # Collect the union of metrics explicitly configured across all
+            # sources in the pipeline YAML (e.g. dc2_wasabi.yaml).  This
+            # becomes the allowed_metrics whitelist injected into the
+            # leaderboard config so that only intentional metrics are shown,
+            # regardless of any extra sub-statistics emitted by metric classes.
+            _pipeline_metrics: set = set()
+            for _src in getattr(self.args, "sources", []) or []:
+                if isinstance(_src, dict):
+                    for _m in _src.get("metrics", []) or []:
+                        if isinstance(_m, str):
+                            _pipeline_metrics.add(_m)
+            # Normalise metric names: the pipeline YAML uses "rmsd" but
+            # dctools per-bins data stores the key as "rmse" (Root Mean
+            # Squared Error).  Map the YAML names to the actual data keys so
+            # the allowed_metrics whitelist matches what is in the files.
+            _METRIC_ALIASES = {"rmsd": "rmse"}
+            _pipeline_metrics = {_METRIC_ALIASES.get(m, m) for m in _pipeline_metrics}
+            _lb_cfg = dict(self.leaderboard_custom_config or {})
+            if _pipeline_metrics and "allowed_metrics" not in _lb_cfg:
+                _lb_cfg["allowed_metrics"] = sorted(_pipeline_metrics)
+                logger.debug(
+                    "  Leaderboard metric whitelist from pipeline config: {}",
+                    sorted(_pipeline_metrics),
+                )
             _render_leaderboard(
                 results_dir=_leaderboard_input_dir,
                 output_site_dir=_leaderboard_dir,
-                custom_config=self.leaderboard_custom_config,
+                custom_config=_lb_cfg if _lb_cfg else None,
             )
             # Clean up the temporary input dir
             _shutil.rmtree(_leaderboard_input_dir, ignore_errors=True)
@@ -1718,14 +1899,20 @@ class BaseDCEvaluation:
                     "enabled and that at least one batch produced spatial data)."
                 )
                 self._leaderboard_warnings.append(_msg)
-                logger.warning(f"  [LEADERBOARD INCOMPLETE] {_msg}")
+                logger.opt(colors=True).warning(
+                    f"  <yellow>⚠  [INCOMPLETE]</yellow>  maps.html not generated —"
+                    " no per-bins spatial data found; check per_bins metrics are enabled."
+                )
             else:
-                logger.success(f"  Leaderboard ready  ->  {_leaderboard_dir}")
+                logger.opt(colors=True).success(
+                    f"  <green>✓</green>  Leaderboard ready  <dim>→</dim>"
+                    f"  <cyan>{_leaderboard_dir}</cyan>  <dim>[+{_fmt_elapsed(_t0)}]</dim>"
+                )
             print("")
         except Exception as _lb_exc:
             _msg = f"Leaderboard generation failed: {_lb_exc!r}"
             self._leaderboard_warnings.append(_msg)
-            logger.warning(
-                f"  └  [WARNING] Leaderboard generation failed (non-blocking):\n"
+            logger.opt(colors=True).warning(
+                f"  <yellow>└  ⚠  Leaderboard generation failed (non-blocking):</yellow>\n"
                 f"              {_lb_exc!r}"
             )

--- a/dctools/processing/runner.py
+++ b/dctools/processing/runner.py
@@ -64,6 +64,50 @@ def resolve_config_path(default_config_name: str, cli_args: Any) -> Path:
     return _challenge_config_dir() / f"{config_name}.yaml"
 
 
+_BANNER_STYLES = {
+    "success": {"icon": "\u2714", "border": "\u2550", "corner": ("\u2554", "\u2557", "\u255a", "\u255d"), "side": "\u2551", "color": "\033[1;32m"},
+    "warning": {"icon": "\u26a0", "border": "\u2550", "corner": ("\u2554", "\u2557", "\u255a", "\u255d"), "side": "\u2551", "color": "\033[1;33m"},
+    "error":   {"icon": "\u2718", "border": "\u2550", "corner": ("\u2554", "\u2557", "\u255a", "\u255d"), "side": "\u2551", "color": "\033[1;31m"},
+}
+_RESET = "\033[0m"
+
+
+def _print_banner(
+    message: str,
+    *,
+    details: Optional[list[str]] = None,
+    style: str = "success",
+    width: int = 60,
+) -> None:
+    """Print a prominent box-styled banner to the terminal."""
+    s = _BANNER_STYLES.get(style, _BANNER_STYLES["success"])
+    c, r = s["color"], _RESET
+    tl, tr, bl, br = s["corner"]
+    side, border, icon = s["side"], s["border"], s["icon"]
+
+    inner = width - 2  # space inside the side borders
+    top = f"{tl}{border * inner}{tr}"
+    bot = f"{bl}{border * inner}{br}"
+    empty = f"{side}{' ' * inner}{side}"
+
+    title = f" {icon}  {message}  {icon} "
+    pad = max(inner - len(title), 0)
+    left_pad = pad // 2
+    right_pad = pad - left_pad
+    title_line = f"{side}{' ' * left_pad}{title}{' ' * right_pad}{side}"
+
+    print(f"\n{c}{top}")
+    print(empty)
+    print(title_line)
+    if details:
+        print(empty)
+        for d in details:
+            d_pad = max(inner - len(d) - 4, 0)
+            print(f"{side}  {d}{' ' * (d_pad + 2)}{side}")
+    print(empty)
+    print(f"{bot}{r}\n")
+
+
 def run_from_config(
     config_path: Path,
     evaluation_cls: Optional[Type[object]] = None,
@@ -126,27 +170,40 @@ def run_from_config(
         report_path = os.path.join(args.result_dir, "dask-report.html")
         print(f"Generating Dask performance report at: {report_path}")
 
-        with performance_report(filename=report_path):
-            evaluator_instance.run_eval()  # type: ignore[attr-defined]
+        try:
+            with performance_report(filename=report_path):
+                evaluator_instance.run_eval()  # type: ignore[attr-defined]
+        except ValueError as _pr_exc:
+            # The Dask cluster is shut down inside run_eval() before
+            # post-processing to free worker RAM.  performance_report's
+            # __exit__ calls get_client() which raises ValueError when no
+            # client exists.  The evaluation itself succeeded — just skip
+            # the performance report.
+            if "No global client found" in str(_pr_exc):
+                pass  # cluster already closed during post-processing; report skipped
+            else:
+                raise
 
         lb_warnings = getattr(evaluator_instance, "_leaderboard_warnings", [])
         if lb_warnings:
-            print("Evaluation has finished, but the leaderboard is INCOMPLETE:")
-            for w in lb_warnings:
-                print(f"  [!] {w}")
+            _print_banner(
+                "Evaluation finished — leaderboard INCOMPLETE",
+                details=[f"[!] {w}" for w in lb_warnings],
+                style="warning",
+            )
             return 0
-        print("Evaluation has finished successfully.")
+        _print_banner("Evaluation has finished successfully", style="success")
         return 0
 
     except KeyboardInterrupt:
-        print("Manual abort.")
+        _print_banner("Evaluation aborted (manual interrupt)", style="error")
         return 1
     except SystemExit:
-        print("SystemExit.")
+        _print_banner("Evaluation aborted (SystemExit)", style="error")
         return 1
     except Exception as exc:
         traceback.print_exc()
-        print(f"Evaluation failed: {exc}")
+        _print_banner(f"Evaluation failed: {exc}", style="error")
         return 1
     finally:
         if evaluator_instance is not None:

--- a/dctools/utilities/args_config.py
+++ b/dctools/utilities/args_config.py
@@ -22,10 +22,13 @@ TIME_VARIABLES = [
 
 LOGGER_CONFIG = {
     "log_level": "DEBUG",
+    # Format inspired by cargo / uv: dim timestamp, level badge, clean message.
+    # File/line info is omitted from the default user-facing format – it's
+    # available via --log-level DEBUG and the optional log-file sink.
     "log_format": (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS zz}</green> | "
-        "<level>{level: <8}</level> | "
-        "<yellow>Line {line: >4} ({file}):</yellow> <b>{message}</b>"
+        "<dim>{time:HH:mm:ss}</dim>"
+        "  <level>{level: <8}</level>"
+        "  {message}"
     ),
 }
 
@@ -146,6 +149,15 @@ def configure_logging_from_args(args: Namespace) -> None:
             _py_logging.getLogger("dask").setLevel(py_level_n)
         except Exception:
             pass
+
+    # Install a permanent filter on distributed.* loggers so benign INFO
+    # connection-close chatter is suppressed even when distributed resets
+    # its own log levels during cluster creation/teardown.
+    try:
+        from dctools.utilities.init_dask import _install_distributed_noise_filter
+        _install_distributed_noise_filter()
+    except Exception:
+        pass
 
 
 def parse_arguments(cli_args: Optional[List[str]] = None) -> Namespace:

--- a/dctools/utilities/init_dask.py
+++ b/dctools/utilities/init_dask.py
@@ -1,10 +1,76 @@
 """Dask initialization and configuration functions."""
 
 import logging
+import logging.config as _logging_config
 import warnings
 
 import dask
 from loguru import logger
+
+
+# ---------------------------------------------------------------------------
+# Permanent noise filter for distributed.* loggers
+# ---------------------------------------------------------------------------
+
+_DISTRIBUTED_NOISE_LOGGERS = (
+    "distributed",
+    "distributed.core",
+    "distributed.comm",
+    "distributed.nanny",
+    "distributed.scheduler",
+    "distributed.worker",
+    "distributed.utils",
+    "distributed.client",
+    "tornado.application",
+)
+
+_NOISE_SUBSTRINGS = (
+    "has been closed",
+    "Connection to tcp://",
+    "Closing dangling",
+    "Event loop was unresponsive",
+    "Worker exceeded",
+    "Scheduler is unable to accept new work",
+    "Timed out trying to connect",
+)
+
+
+class _DistributedNoiseFilter(logging.Filter):
+    """Drop benign distributed INFO chatter regardless of level changes."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        if record.levelno >= logging.WARNING:
+            return True
+        msg = record.getMessage()
+        return not any(s in msg for s in _NOISE_SUBSTRINGS)
+
+
+def _install_distributed_noise_filter() -> None:
+    """Attach _DistributedNoiseFilter to all distributed.* loggers and set ERROR level."""
+    _filter = _DistributedNoiseFilter()
+    for name in _DISTRIBUTED_NOISE_LOGGERS:
+        _lg = logging.getLogger(name)
+        _lg.setLevel(logging.WARNING)
+        if not any(isinstance(f, _DistributedNoiseFilter) for f in _lg.filters):
+            _lg.addFilter(_filter)
+
+
+# Monkey-patch logging.config.dictConfig so that whenever distributed calls it
+# (during LocalCluster creation/teardown) our filter is re-applied afterwards.
+# distributed calls dictConfig to reset log levels from dask config, which
+# wipes any filters we added.  The patch ensures they're always restored.
+_orig_dictConfig = _logging_config.dictConfig
+
+
+def _noise_aware_dictConfig(config: dict) -> None:  # type: ignore[type-arg]
+    _orig_dictConfig(config)
+    try:
+        _install_distributed_noise_filter()
+    except Exception:
+        pass
+
+
+_logging_config.dictConfig = _noise_aware_dictConfig
 
 
 def configure_dask_workers_env(client):
@@ -115,27 +181,16 @@ def configure_dask_workers_env(client):
 
 def configure_dask_logging():
     """Configure Dask logs to be quiet."""
-    # Remove noisy Dask-specific loggers
-    dask_loggers = [
-        "distributed",
-        "distributed.core",
-        "distributed.worker",
-        "distributed.scheduler",
-        "distributed.nanny",
-        "distributed.comm",
-        "distributed.utils",
-        "distributed.client",
-        "tornado.application",
-    ]
-
-    for logger_name in dask_loggers:
-        logging.getLogger(logger_name).setLevel(logging.ERROR)
+    # Set all distributed.* loggers to WARNING (filter handles the rest).
+    _install_distributed_noise_filter()
 
     # Silence Dask warnings
     warnings.filterwarnings("ignore", category=UserWarning, module="distributed")
     warnings.filterwarnings("ignore", message=".*Event loop was unresponsive.*")
 
-    # Global Dask configuration
+    # Global Dask configuration.
+    # The "logging" key is read by distributed's setup_logging() when it calls
+    # logging.config.dictConfig — use a flat {loggerName: level} mapping.
     dask.config.set(
         {
             "distributed.worker.daemon": False,
@@ -148,10 +203,15 @@ def configure_dask_logging():
             "distributed.worker.memory.pause": 0.95,
             "distributed.worker.memory.terminate": False,
             "logging": {
-                "distributed": {
-                    "": "error",  # root "distributed" logger
-                    "worker": "error",  # sub-logger: distributed.worker
-                }
+                "distributed": "error",
+                "distributed.core": "error",
+                "distributed.comm": "error",
+                "distributed.nanny": "error",
+                "distributed.scheduler": "error",
+                "distributed.worker": "error",
+                "distributed.utils": "error",
+                "distributed.client": "error",
+                "tornado.application": "error",
             },
         }
     )

--- a/dctools/utilities/machine_profile.py
+++ b/dctools/utilities/machine_profile.py
@@ -107,7 +107,7 @@ def _should_fill(key: str, src: dict, global_auto: bool) -> bool:
     value = src[key]
     if _is_explicit(value):
         return False  # user pinned an explicit number — never override
-    # None / "auto" → always fill
+    # None / "auto" --> always fill
     return _is_auto_sentinel(value)
 
 
@@ -191,7 +191,7 @@ def _zarr_uncompressed_per_timestep_mb(
         for key, val in metadata.items():
             if not key.endswith("/.zarray"):
                 continue
-            # e.g. "ssha_filtered/.zarray" → var_name = "ssha_filtered"
+            # e.g. "ssha_filtered/.zarray" --> var_name = "ssha_filtered"
             var_name = key[:-8].lstrip("/").split("/")[-1]
             shape = val.get("shape", [])
             try:
@@ -494,12 +494,12 @@ def _obs_batch_size(driver_reserve_gb: float, *, is_swath: bool) -> int:
 
     *obs_batch_size* controls how many evaluation time-windows are batched
     together before the driver preprocesses their observation files.  More
-    windows → more unique files → more driver RAM consumed.
+    windows --> more unique files --> more driver RAM consumed.
 
-    * Swath datasets (SWOT): each file is large (~200 MB uncompressed) → a
+    * Swath datasets (SWOT): each file is large (~200 MB uncompressed) --> a
       budget of 0.5 GB per window gives conservative batches.
     * Nadir / profile datasets (SARAL, Jason-3, …): files are small (~5 MB)
-      → a budget of 0.15 GB per window allows larger batches.
+      --> a budget of 0.15 GB per window allows larger batches.
     """
     if is_swath:
         return max(5, min(15, int(driver_reserve_gb / 0.5) + 1))

--- a/dctools/utilities/misc_utils.py
+++ b/dctools/utilities/misc_utils.py
@@ -201,18 +201,30 @@ def serialize_structure(obj):
 
 
 def to_float32(obj: Any) -> Any:
-    """Recursively converts all float64 data to float32 in xarray objects or dicts."""
+    """Recursively converts all float64 data to float32 in xarray objects or dicts.
+
+    Copy-on-cast: only copies the Dataset/DataArray when at least one variable
+    actually needs a dtype conversion.  If every floating variable is already
+    float32 the original object is returned unchanged — avoiding a full
+    in-memory duplicate of potentially hundreds of MB of data.
+    Works on both lazy (dask-backed) and already-computed (numpy) objects.
+    """
     if isinstance(obj, xr.Dataset):
-        # Specific implementation for Dataset to be safe with types
+        # Identify variables that genuinely need a cast.
+        needs_cast = [
+            var for var in obj.data_vars
+            if np.issubdtype(obj[var].dtype, np.floating) and obj[var].dtype != np.float32
+        ]
+        if not needs_cast:
+            return obj  # All floats already float32 (or no float vars) — skip copy.
         ds = obj.copy()
-        for var in ds.data_vars:
-            if np.issubdtype(ds[var].dtype, np.floating):
-                ds[var] = ds[var].astype("float32")
+        for var in needs_cast:
+            ds[var] = ds[var].astype("float32")
         return ds
     elif isinstance(obj, xr.DataArray):
-        if np.issubdtype(obj.dtype, np.floating):
-            return obj.astype("float32")
-        return obj
+        if not np.issubdtype(obj.dtype, np.floating) or obj.dtype == np.float32:
+            return obj  # Already float32 or non-floating — no copy needed.
+        return obj.astype("float32")
     elif isinstance(obj, dict):
         return {k: to_float32(v) for k, v in obj.items()}
     elif isinstance(obj, list):

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,20 +31,20 @@ test = ["pytest (>=4.6)", "pytest-cov"]
 
 [[package]]
 name = "aiobotocore"
-version = "3.3.0"
+version = "3.4.0"
 description = "Async client for aws services using botocore and aiohttp"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "aiobotocore-3.3.0-py3-none-any.whl", hash = "sha256:9125ab2b63740dfe3b66b8d5a90d13aed9587b850aa53225ef214a04a1aa7fdc"},
-    {file = "aiobotocore-3.3.0.tar.gz", hash = "sha256:9abc21d91edd6c9c2e4a07e11bdfcbb159f0b9116ab2a0a5a349113533a18fb2"},
+    {file = "aiobotocore-3.4.0-py3-none-any.whl", hash = "sha256:26290eb6830ea92d8a6f5f90b56e9f5cedd6d126074d5db63b195e281d982465"},
+    {file = "aiobotocore-3.4.0.tar.gz", hash = "sha256:a918b5cb903f81feba7e26835aed4b5e6bb2d0149d7f42bb2dd7d8089e3d9000"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.12.0,<4.0.0"
 aioitertools = ">=0.5.1,<1.0.0"
-botocore = ">=1.42.62,<1.42.71"
+botocore = ">=1.42.79,<1.42.85"
 jmespath = ">=0.7.1,<2.0.0"
 multidict = ">=6.0.0,<7.0.0"
 python-dateutil = ">=2.1,<3.0.0"
@@ -67,132 +67,132 @@ files = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.3"
+version = "3.13.5"
 description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "custom"]
 files = [
-    {file = "aiohttp-3.13.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a372fd5afd301b3a89582817fdcdb6c34124787c70dbcc616f259013e7eef7"},
-    {file = "aiohttp-3.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:147e422fd1223005c22b4fe080f5d93ced44460f5f9c105406b753612b587821"},
-    {file = "aiohttp-3.13.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:859bd3f2156e81dd01432f5849fc73e2243d4a487c4fd26609b1299534ee1845"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dca68018bf48c251ba17c72ed479f4dafe9dbd5a73707ad8d28a38d11f3d42af"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fee0c6bc7db1de362252affec009707a17478a00ec69f797d23ca256e36d5940"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c048058117fd649334d81b4b526e94bde3ccaddb20463a815ced6ecbb7d11160"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:215a685b6fbbfcf71dfe96e3eba7a6f58f10da1dfdf4889c7dd856abe430dca7"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c184bb1fe2cbd2cefba613e9db29a5ab559323f994b6737e370d3da0ac455"},
-    {file = "aiohttp-3.13.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75ca857eba4e20ce9f546cd59c7007b33906a4cd48f2ff6ccf1ccfc3b646f279"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81e97251d9298386c2b7dbeb490d3d1badbdc69107fb8c9299dd04eb39bddc0e"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c0e2d366af265797506f0283487223146af57815b388623f0357ef7eac9b209d"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4e239d501f73d6db1522599e14b9b321a7e3b1de66ce33d53a765d975e9f4808"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0db318f7a6f065d84cb1e02662c526294450b314a02bd9e2a8e67f0d8564ce40"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:bfc1cc2fe31a6026a8a88e4ecfb98d7f6b1fec150cfd708adbfd1d2f42257c29"},
-    {file = "aiohttp-3.13.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af71fff7bac6bb7508956696dce8f6eec2bbb045eceb40343944b1ae62b5ef11"},
-    {file = "aiohttp-3.13.3-cp310-cp310-win32.whl", hash = "sha256:37da61e244d1749798c151421602884db5270faf479cf0ef03af0ff68954c9dd"},
-    {file = "aiohttp-3.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:7e63f210bc1b57ef699035f2b4b6d9ce096b5914414a49b0997c839b2bd2223c"},
-    {file = "aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b"},
-    {file = "aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64"},
-    {file = "aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1"},
-    {file = "aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4"},
-    {file = "aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29"},
-    {file = "aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239"},
-    {file = "aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f"},
-    {file = "aiohttp-3.13.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b903a4dfee7d347e2d87697d0713be59e0b87925be030c9178c5faa58ea58d5c"},
-    {file = "aiohttp-3.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a45530014d7a1e09f4a55f4f43097ba0fd155089372e105e4bff4ca76cb1b168"},
-    {file = "aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27234ef6d85c914f9efeb77ff616dbf4ad2380be0cda40b4db086ffc7ddd1b7d"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d32764c6c9aafb7fb55366a224756387cd50bfa720f32b88e0e6fa45b27dcf29"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1a6102b4d3ebc07dad44fbf07b45bb600300f15b552ddf1851b5390202ea2e3"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c014c7ea7fb775dd015b2d3137378b7be0249a448a1612268b5a90c2d81de04d"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b8d8ddba8f95ba17582226f80e2de99c7a7948e66490ef8d947e272a93e9463"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ae8dd55c8e6c4257eae3a20fd2c8f41edaea5992ed67156642493b8daf3cecc"},
-    {file = "aiohttp-3.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01ad2529d4b5035578f5081606a465f3b814c542882804e2e8cda61adf5c71bf"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bb4f7475e359992b580559e008c598091c45b5088f28614e855e42d39c2f1033"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c19b90316ad3b24c69cd78d5c9b4f3aa4497643685901185b65166293d36a00f"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:96d604498a7c782cb15a51c406acaea70d8c027ee6b90c569baa6e7b93073679"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:084911a532763e9d3dd95adf78a78f4096cd5f58cdc18e6fdbc1b58417a45423"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7a4a94eb787e606d0a09404b9c38c113d3b099d508021faa615d70a0131907ce"},
-    {file = "aiohttp-3.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87797e645d9d8e222e04160ee32aa06bc5c163e8499f24db719e7852ec23093a"},
-    {file = "aiohttp-3.13.3-cp312-cp312-win32.whl", hash = "sha256:b04be762396457bef43f3597c991e192ee7da460a4953d7e647ee4b1c28e7046"},
-    {file = "aiohttp-3.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:e3531d63d3bdfa7e3ac5e9b27b2dd7ec9df3206a98e0b3445fa906f233264c57"},
-    {file = "aiohttp-3.13.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dff64413671b0d3e7d5918ea490bdccb97a4ad29b3f311ed423200b2203e01c"},
-    {file = "aiohttp-3.13.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:87b9aab6d6ed88235aa2970294f496ff1a1f9adcd724d800e9b952395a80ffd9"},
-    {file = "aiohttp-3.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:425c126c0dc43861e22cb1c14ba4c8e45d09516d0a3ae0a3f7494b79f5f233a3"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f9120f7093c2a32d9647abcaf21e6ad275b4fbec5b55969f978b1a97c7c86bf"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:697753042d57f4bf7122cab985bf15d0cef23c770864580f5af4f52023a56bd6"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6de499a1a44e7de70735d0b39f67c8f25eb3d91eb3103be99ca0fa882cdd987d"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37239e9f9a7ea9ac5bf6b92b0260b01f8a22281996da609206a84df860bc1261"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f76c1e3fe7d7c8afad7ed193f89a292e1999608170dcc9751a7462a87dfd5bc0"},
-    {file = "aiohttp-3.13.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fc290605db2a917f6e81b0e1e0796469871f5af381ce15c604a3c5c7e51cb730"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4021b51936308aeea0367b8f006dc999ca02bc118a0cc78c303f50a2ff6afb91"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49a03727c1bba9a97d3e93c9f93ca03a57300f484b6e935463099841261195d3"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3d9908a48eb7416dc1f4524e69f1d32e5d90e3981e4e37eb0aa1cd18f9cfa2a4"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2712039939ec963c237286113c68dbad80a82a4281543f3abf766d9d73228998"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7bfdc049127717581866fa4708791220970ce291c23e28ccf3922c700740fdc0"},
-    {file = "aiohttp-3.13.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8057c98e0c8472d8846b9c79f56766bcc57e3e8ac7bfd510482332366c56c591"},
-    {file = "aiohttp-3.13.3-cp313-cp313-win32.whl", hash = "sha256:1449ceddcdbcf2e0446957863af03ebaaa03f94c090f945411b61269e2cb5daf"},
-    {file = "aiohttp-3.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:693781c45a4033d31d4187d2436f5ac701e7bbfe5df40d917736108c1cc7436e"},
-    {file = "aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808"},
-    {file = "aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415"},
-    {file = "aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1"},
-    {file = "aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c"},
-    {file = "aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43"},
-    {file = "aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1"},
-    {file = "aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767"},
-    {file = "aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344"},
-    {file = "aiohttp-3.13.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31a83ea4aead760dfcb6962efb1d861db48c34379f2ff72db9ddddd4cda9ea2e"},
-    {file = "aiohttp-3.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:988a8c5e317544fdf0d39871559e67b6341065b87fceac641108c2096d5506b7"},
-    {file = "aiohttp-3.13.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b174f267b5cfb9a7dba9ee6859cecd234e9a681841eb85068059bc867fb8f02"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:947c26539750deeaee933b000fb6517cc770bbd064bad6033f1cff4803881e43"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9ebf57d09e131f5323464bd347135a88622d1c0976e88ce15b670e7ad57e4bd6"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4ae5b5a0e1926e504c81c5b84353e7a5516d8778fbbff00429fe7b05bb25cbce"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2ba0eea45eb5cc3172dbfc497c066f19c41bac70963ea1a67d51fc92e4cf9a80"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bae5c2ed2eae26cc382020edad80d01f36cb8e746da40b292e68fec40421dc6a"},
-    {file = "aiohttp-3.13.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8a60e60746623925eab7d25823329941aee7242d559baa119ca2b253c88a7bd6"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e50a2e1404f063427c9d027378472316201a2290959a295169bcf25992d04558"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:9a9dc347e5a3dc7dfdbc1f82da0ef29e388ddb2ed281bfce9dd8248a313e62b7"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:b46020d11d23fe16551466c77823df9cc2f2c1e63cc965daf67fa5eec6ca1877"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:69c56fbc1993fa17043e24a546959c0178fe2b5782405ad4559e6c13975c15e3"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:b99281b0704c103d4e11e72a76f1b543d4946fea7dd10767e7e1b5f00d4e5704"},
-    {file = "aiohttp-3.13.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:40c5e40ecc29ba010656c18052b877a1c28f84344825efa106705e835c28530f"},
-    {file = "aiohttp-3.13.3-cp39-cp39-win32.whl", hash = "sha256:56339a36b9f1fc708260c76c87e593e2afb30d26de9ae1eb445b5e051b98a7a1"},
-    {file = "aiohttp-3.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:c6b8568a3bb5819a0ad087f16d40e5a3fb6099f39ea1d5625a3edc1e923fc538"},
-    {file = "aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f546a4dc1e6a5edbb9fd1fd6ad18134550e096a5a43f4ad74acfbd834fc6670"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c86969d012e51b8e415a8c6ce96f7857d6a87d6207303ab02d5d11ef0cad2274"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b6f6cd1560c5fa427e3b6074bb24d2c64e225afbb7165008903bd42e4e33e28a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:636bc362f0c5bbc7372bc3ae49737f9e3030dbce469f0f422c8f38079780363d"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a7cbeb06d1070f1d14895eeeed4dac5913b22d7b456f2eb969f11f4b3993796"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca9ef7517fd7874a1a08970ae88f497bf5c984610caa0bf40bd7e8450852b95"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:019a67772e034a0e6b9b17c13d0a8fe56ad9fb150fc724b7f3ffd3724288d9e5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f34ecee82858e41dd217734f0c41a532bd066bcaab636ad830f03a30b2a96f2a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4eac02d9af4813ee289cd63a361576da36dba57f5a1ab36377bc2600db0cbb73"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4beac52e9fe46d6abf98b0176a88154b742e878fdf209d2248e99fcdf73cd297"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c180f480207a9b2475f2b8d8bd7204e47aec952d084b2a2be58a782ffcf96074"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2837fb92951564d6339cedae4a7231692aa9f73cbc4fb2e04263b96844e03b4e"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d9010032a0b9710f58012a1e9c222528763d860ba2ee1422c03473eab47703e7"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win32.whl", hash = "sha256:7c4b6668b2b2b9027f209ddf647f2a4407784b5d88b8be4efcc72036f365baf9"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:cd3db5927bf9167d5a6157ddb2f036f6b6b0ad001ac82355d43e97a4bde76d76"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:347542f0ea3f95b2a955ee6656461fa1c776e401ac50ebce055a6c38454a0adf"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:178c7b5e62b454c2bc790786e6058c3cc968613b4419251b478c153a4aec32b1"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af545c2cffdb0967a96b6249e6f5f7b0d92cdfd267f9d5238d5b9ca63e8edb10"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:206b7b3ef96e4ce211754f0cd003feb28b7d81f0ad26b8d077a5d5161436067f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ee5e86776273de1795947d17bddd6bb19e0365fd2af4289c0d2c5454b6b1d36b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95d14ca7abefde230f7639ec136ade282655431fd5db03c343b19dda72dd1643"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:912d4b6af530ddb1338a66229dac3a25ff11d4448be3ec3d6340583995f56031"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e999f0c88a458c836d5fb521814e92ed2172c649200336a6df514987c1488258"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39380e12bd1f2fdab4285b6e055ad48efbaed5c836433b142ed4f5b9be71036a"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9efcc0f11d850cefcafdd9275b9576ad3bfb539bed96807663b32ad99c4d4b88"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:147b4f501d0292077f29d5268c16bb7c864a1f054d7001c4c1812c0421ea1ed0"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d147004fede1b12f6013a6dbb2a26a986a671a03c6ea740ddc76500e5f1c399f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9277145d36a01653863899c665243871434694bcc3431922c3b35c978061bdb8"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4e704c52438f66fdd89588346183d898bb42167cf88f8b7ff1c0f9fc957c348f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a8a4d3427e8de1312ddf309cc482186466c79895b3a139fed3259fc01dfa9a5b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win32.whl", hash = "sha256:6f497a6876aa4b1a102b04996ce4c1170c7040d83faa9387dd921c16e30d5c83"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win_amd64.whl", hash = "sha256:cb979826071c0986a5f08333a36104153478ce6018c58cba7f9caddaf63d5d67"},
+    {file = "aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1"},
 ]
 
 [package.dependencies]
@@ -284,14 +284,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
-    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
+    {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
+    {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
 ]
 
 [package.dependencies]
@@ -299,41 +299,37 @@ idna = ">=2.8"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
+trio = ["trio (>=0.32.0)"]
 
 [[package]]
 name = "apache-beam"
-version = "2.71.0"
+version = "2.72.0"
 description = "Apache Beam SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "apache_beam-2.71.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e1cbc386cf8c0d740b3b2847cb7c99481672ed036b57c11eb2f41d049800b40"},
-    {file = "apache_beam-2.71.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3acb72a5afdc15abe696e37915cbce91d7a0672fda2658c2185d8ea4684d4e3"},
-    {file = "apache_beam-2.71.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e06fb7fd4f5aa9d16bb8d8d30d9c24fc255cfc9be510188bfab0b11f398cc515"},
-    {file = "apache_beam-2.71.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4a3b4008ca3966f426a8580535e2227387518a2d62c3928c4e3d5a6ca23dd8a"},
-    {file = "apache_beam-2.71.0-cp310-cp310-win32.whl", hash = "sha256:43ed7ae3dbecf67af2ad412b86d160fc6177d19fc6e59ed18aee4a84355858db"},
-    {file = "apache_beam-2.71.0-cp310-cp310-win_amd64.whl", hash = "sha256:78c2f8e88014555984a7a21bcb63479e135b958428d178d45699a4154ae84634"},
-    {file = "apache_beam-2.71.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3705d824d462aee4bf162318eb0ef1ca767064e73aa4f1ba14d741cc12c19143"},
-    {file = "apache_beam-2.71.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28c6eeb05b688dcc503fce84075fcd03a73bbd9e449e70521f2efb47a932bcea"},
-    {file = "apache_beam-2.71.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a11147b82260d69b19021b32a65da044d38f65195ec2a66460ccad80649106b5"},
-    {file = "apache_beam-2.71.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81766907e53a5feddb2d1b5553c6f1154ff7cae67e548b4c2726e299334572bf"},
-    {file = "apache_beam-2.71.0-cp311-cp311-win32.whl", hash = "sha256:1cdaf7e502da67f674ecf8dd8cec21252bd1b2678a5d18b873a45635cf0e7cec"},
-    {file = "apache_beam-2.71.0-cp311-cp311-win_amd64.whl", hash = "sha256:a358a7e689e1acb903ec5f545ed22b674fb6cbb17424518630412cba3a627937"},
-    {file = "apache_beam-2.71.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:192b00d13de8eb06241c5332ecef7a9a947758e2103b07d6726848ba9f0b5a49"},
-    {file = "apache_beam-2.71.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ca7fca47ae39b5e6497c39bca303d11c200fdfae6b352e5e481a59a9b886f75"},
-    {file = "apache_beam-2.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8189d2e1d314a7dc8f3456bae4c7641637d302490e1af93db3aa6ba45d716b70"},
-    {file = "apache_beam-2.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de890d820ae365eddcbe522e61816a967ab9d5be501fb56435e0d8a8c571408e"},
-    {file = "apache_beam-2.71.0-cp312-cp312-win32.whl", hash = "sha256:a7967a1d75daec31e9d03705304ad4e7e5bcad266dd5e8bad98a68e76ebb368f"},
-    {file = "apache_beam-2.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:af5a9acf850b8430440f8e6f687650c252dd7d0b929fbef2d84ce79087f6bb6b"},
-    {file = "apache_beam-2.71.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:78e3e913275bd1c1aac1ecc90af78fb65915908671b6e39d60a3a31de3438782"},
-    {file = "apache_beam-2.71.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:044841032ef190a7ad69a9d4ca4b23c104a310d08c47a1f5faefcf830c9e5520"},
-    {file = "apache_beam-2.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c015aa7ee75cabc58277b19317429fc3ed08752173d6750b2212260190505c7f"},
-    {file = "apache_beam-2.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:317f5495c3266b9146263dbb881110b56b015fbc7e2f1e27eb9932b2bf28a94c"},
-    {file = "apache_beam-2.71.0-cp313-cp313-win32.whl", hash = "sha256:83be2fce3726529f221c8d99f844f64d68494b2bad438852f96f02f2c0e8cac8"},
-    {file = "apache_beam-2.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:a14fb6972de7113dfbe6bba967de1a3a5c60228a96b96eb32a675762f83d659b"},
-    {file = "apache_beam-2.71.0.tar.gz", hash = "sha256:515064493c478e92a87618f46c8b8c2143ce244317db683dc3d824fda37b0db5"},
+    {file = "apache_beam-2.72.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:517758c7dfcbade1f580822a9371aa626df0b93adbede6f605c12e82707961a2"},
+    {file = "apache_beam-2.72.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:178d6fcc84e7ce1448adaaa0d6583e8467a12bd4d3556c30289f361aacc9e3a9"},
+    {file = "apache_beam-2.72.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cdb8fa6c08c8dea0ad1f9e7d8b36b99f6dd3c49f58c12cc0dcb44f8c912b811b"},
+    {file = "apache_beam-2.72.0-cp310-cp310-win32.whl", hash = "sha256:818fa1625b4b5fa12852f7a347982d978b19146ca13c06a2b1bc5f96a91ccc45"},
+    {file = "apache_beam-2.72.0-cp310-cp310-win_amd64.whl", hash = "sha256:06e3ec4cbf97b4c5a8c6e73823cee6d85b87d47c6edb485e8b6ed18a8886e836"},
+    {file = "apache_beam-2.72.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d0230a274a0db161fc6bff52f2887ecfe777717f43c925c4bc161f805191d21c"},
+    {file = "apache_beam-2.72.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d44e2ff6b40ce447fd23e9d3d02429647b5bbbe14574198b4870be66ca0dace"},
+    {file = "apache_beam-2.72.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8138c8772803c432e3218a3dee5190feece4a7216883a0ec42cc71476db080ac"},
+    {file = "apache_beam-2.72.0-cp311-cp311-win32.whl", hash = "sha256:2c9dd7d5730c0fd97ae33ddc4912d126c62043b2936dea80ec1023da203a1e2d"},
+    {file = "apache_beam-2.72.0-cp311-cp311-win_amd64.whl", hash = "sha256:6ec591e09d125c93ae0c0286cdc1fe21f6c2f6b0fed7090704e1f9a3ea54af63"},
+    {file = "apache_beam-2.72.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5c1688894f7dd60da68111168d0abdb3a997c9277ae1ca0f5692b32f3205bd7"},
+    {file = "apache_beam-2.72.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f1097ff9969276f35dd31b2247f06dd844510be3f93d5370fb6237eae462d4e"},
+    {file = "apache_beam-2.72.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9b1c13f081aed2e1c7c411827d6d3c3cc6ffc9aa0c0445fe5e132de1d20071a"},
+    {file = "apache_beam-2.72.0-cp312-cp312-win32.whl", hash = "sha256:4470453c76b2d86558e916b86cfa0e5dc9d0d525ad12d680e5684aa8226c77c7"},
+    {file = "apache_beam-2.72.0-cp312-cp312-win_amd64.whl", hash = "sha256:0674cb64ea27290b2303d3348125e244ba0fc551a94fc061775dc6a8ee3cd26d"},
+    {file = "apache_beam-2.72.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3c3a260948fd60684747e8b68ea482eaa6eb06cdae7c723e9385ee91c093dbce"},
+    {file = "apache_beam-2.72.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ccb2647dce66f7820bb7baf8dee4424ab11b36c14bdf5c4b7c5635c4464a54c4"},
+    {file = "apache_beam-2.72.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eab8631b15e0015cd9125e6a3648d0d6960ddda0f6a18b4bd62b9ad72153b6ff"},
+    {file = "apache_beam-2.72.0-cp313-cp313-win32.whl", hash = "sha256:7608878eecde0cc023df26a15960c0e6ae2546bd9f7cb197b66417a51a846517"},
+    {file = "apache_beam-2.72.0-cp313-cp313-win_amd64.whl", hash = "sha256:4be89be9c916cf8c25184ea84d0e3fe2d950a2e9fa92f360b7f49bdbd3176553"},
+    {file = "apache_beam-2.72.0.tar.gz", hash = "sha256:4e2b13e6e19b044c23f2800269f59c902bf569f5cecc892e9040efde1fd52b78"},
 ]
 
 [package.dependencies]
@@ -345,18 +341,16 @@ envoy-data-plane = [
 ]
 fastavro = ">=0.23.6,<2"
 fasteners = ">=0.3,<1.0"
-grpcio = [
-    {version = ">=1.67.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.33.1,<1.48.0 || >1.48.0,<1.59.dev0 || >1.62.0,<1.62.1 || >1.62.1,<1.66.0", markers = "python_version <= \"3.12\""},
-]
-httplib2 = ">=0.8,<0.23.0"
+grpcio = ">=1.33.1,<1.48.0 || >1.48.0,<1.59.dev0 || >1.62.0,<1.62.1 || >1.62.1,<1.66.dev0 || >=1.71.dev0,<2"
+httplib2 = ">=0.8,<0.32.0"
 jsonpickle = ">=3.0.0,<4.0.0"
 numpy = ">=1.14.3,<2.5.0"
 objsize = ">=0.6.1,<0.8.0"
 packaging = ">=22.0"
+pillow = ">=12.1.1,<13"
 proto-plus = ">=1.7.1,<2"
 protobuf = ">=3.20.3,<4.0.dev0 || >=4.1.dev0,<4.21.dev0 || >4.22.0,<4.23.dev0 || >=4.25.dev0,<7.0.0.dev0"
-pyarrow = ">=3.0.0,<19.0.0"
+pyarrow = ">=6.0.1,<24.0.0"
 pyarrow-hotfix = "<1"
 pymongo = ">=3.8.0,<5.0.0"
 python-dateutil = ">=2.8.0,<3"
@@ -374,20 +368,21 @@ dask = ["dask (>=2024.4.2)", "distributed (>=2024.4.2)"]
 dataframe = ["pandas (>=1.4.3,!=1.5.0,!=1.5.1,<2.3)"]
 dill = ["dill (>=0.3.1.1,<0.3.2)"]
 docs = ["Sphinx (>=7.0.0,<8.0)", "docstring-parser (>=0.15,<1.0)", "docutils (>=0.18.1)", "jinja2 (>=3.0,<3.2)", "markdown", "openai", "pandas (<2.3.0)", "virtualenv-clone (>=0.5,<1.0)"]
-gcp = ["PyMySQL (>=1.1.0)", "cachetools (>=3.1.0,<7)", "cloud-sql-python-connector (>=1.18.2,<2.0.0)", "google-api-core (>=2.0.0,<3)", "google-apitools (>=0.5.31,<0.5.32) ; python_version < \"3.13\"", "google-apitools (>=0.5.35) ; python_version >= \"3.13\"", "google-auth (>=1.18.0,<3)", "google-auth-httplib2 (>=0.1.0,<0.3.0)", "google-cloud-aiplatform (>=1.26.0,<2.0)", "google-cloud-bigquery (>=2.0.0,<4)", "google-cloud-bigquery-storage (>=2.6.3,<3)", "google-cloud-bigtable (>=2.19.0,<3)", "google-cloud-core (>=2.0.0,<3)", "google-cloud-datastore (>=2.0.0,<3)", "google-cloud-dlp (>=3.0.0,<4)", "google-cloud-kms (>=3.0.0,<4)", "google-cloud-language (>=2.0,<3)", "google-cloud-pubsub (>=2.1.0,<3)", "google-cloud-pubsublite (>=1.2.0,<2)", "google-cloud-recommendations-ai (>=0.1.0,<0.11.0)", "google-cloud-secret-manager (>=2.0,<3)", "google-cloud-spanner (>=3.0.0,<4)", "google-cloud-storage (>=2.18.2,<3)", "google-cloud-videointelligence (>=2.0,<3)", "google-cloud-vision (>=2,<4)", "keyrings.google-artifactregistry-auth", "orjson (>=3.9.7,<4)", "pg8000 (>=1.31.5)", "python-tds (>=1.16.1)", "regex (>=2020.6.8)"]
+gcp = ["PyMySQL (>=1.1.0)", "cachetools (>=3.1.0,<7)", "cloud-sql-python-connector (>=1.18.2,<2.0.0)", "google-api-core (>=2.0.0,<3)", "google-apitools (>=0.5.31,<0.5.32) ; python_version < \"3.13\"", "google-apitools (>=0.5.35) ; python_version >= \"3.13\"", "google-auth (>=1.18.0,<3)", "google-auth-httplib2 (>=0.1.0,<0.3.0)", "google-cloud-aiplatform (>=1.26.0,<2.0)", "google-cloud-bigquery (>=2.0.0,<4)", "google-cloud-bigquery-storage (>=2.6.3,<3)", "google-cloud-bigtable (>=2.19.0,<3)", "google-cloud-build (>=3.35.0,<4)", "google-cloud-core (>=2.0.0,<3)", "google-cloud-datastore (>=2.0.0,<3)", "google-cloud-dlp (>=3.0.0,<4)", "google-cloud-kms (>=3.0.0,<4)", "google-cloud-language (>=2.0,<3)", "google-cloud-pubsub (>=2.1.0,<3)", "google-cloud-recommendations-ai (>=0.1.0,<0.11.0)", "google-cloud-secret-manager (>=2.0,<3)", "google-cloud-spanner (>=3.0.0,<4)", "google-cloud-storage (>=2.18.2,<3)", "google-cloud-videointelligence (>=2.0,<3)", "google-cloud-vision (>=2,<4)", "keyrings.google-artifactregistry-auth", "orjson (>=3.9.7,<4)", "pg8000 (>=1.31.5)", "python-tds (>=1.16.1)", "regex (>=2020.6.8)"]
 hadoop = ["hdfs (>=2.1.0,<3.0.0)"]
 interactive = ["facets-overview (>=1.1.0,<2)", "google-cloud-dataproc (>=5.0.0,<6)", "ipykernel (>=6,<7)", "ipython (>=7,<9)", "ipywidgets (>=8,<9)", "jupyter-client (>=6.1.11,!=6.1.13,<8.2.1)", "nbconvert (>=6.2.0,<8)", "nbformat (>=5.0.5,<6)", "pandas (>=1.4.3,!=1.5.0,!=1.5.1,<2.3)", "pydot (>=1.2.0,<2)", "timeloop (>=1.0.2,<2)"]
 interactive-test = ["chromedriver-binary (>=117,<118)", "needle (>=0.5.0,<1)", "pillow (>=7.1.1,<10)", "urllib3 (>=1.21.1,<2)"]
 milvus = ["pymilvus (>=2.5.10,<3.0.0)"]
-ml-cpu = ["tensorflow (>=2.12.0)", "torch (==2.8.0+cpu)", "transformers (>=4.28.0,<4.56.0)"]
-ml-test = ["datatable", "dill", "embeddings", "langchain", "onnxruntime", "pillow", "pyod", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tensorflow-transform", "tf2onnx", "torch", "transformers"]
-onnx = ["onnxruntime (==1.13.1)", "skl2onnx (==1.13)", "tensorflow (==2.11.0)", "tf2onnx (==1.13.0)", "torch (==1.13.1)", "transformers (==4.25.1)"]
-p312-ml-test = ["datatable", "embeddings", "langchain", "onnxruntime", "pillow", "pyod", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tf2onnx", "torch", "transformers"]
-p313-ml-test = ["embeddings", "langchain", "onnxruntime", "pillow", "pyod", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tf2onnx", "torch", "transformers"]
+ml-cpu = ["absl-py (>=0.12.0)", "tensorflow (>=2.12.0)", "torch (==2.8.0+cpu)", "transformers (>=4.28.0,<4.56.0)"]
+ml-test = ["absl-py (>=0.12.0)", "datatable", "dill", "embeddings (>=0.0.4)", "langchain", "onnxruntime", "pyod (>=0.7.6)", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tensorflow-transform", "tf2onnx", "torch", "transformers"]
+onnx = ["absl-py (>=0.12.0)", "onnxruntime (==1.13.1)", "skl2onnx (==1.13)", "tensorflow (==2.11.0)", "tf2onnx (==1.13.0)", "torch (==1.13.1)", "transformers (==4.25.1)"]
+p310-ml-test = ["absl-py (>=0.12.0)", "datatable", "embeddings (>=0.0.4)", "langchain", "onnxruntime", "pyod (>=0.7.6)", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tf2onnx", "torch", "transformers"]
+p312-ml-test = ["absl-py (>=0.12.0)", "datatable", "embeddings (>=0.0.4)", "langchain", "onnxruntime", "pyod (>=0.7.6)", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tf2onnx", "torch", "transformers"]
+p313-ml-test = ["absl-py (>=0.12.0)", "embeddings (>=0.0.4)", "langchain", "onnxruntime", "pymilvus (>=2.5.10,<3.0.0)", "pyod (>=0.7.6)", "sentence-transformers (>=2.2.2)", "skl2onnx", "tensorflow", "tensorflow-hub", "tf2onnx", "torch", "transformers"]
 redis = ["redis (>=5.0.0,<6)"]
-tensorflow = ["tensorflow (>=2.12rc1,<2.21)"]
+tensorflow = ["absl-py (>=0.12.0)", "tensorflow (>=2.12rc1,<2.21)"]
 tensorflow-hub = ["tensorflow-hub (>=0.14.0,<0.16.0)"]
-test = ["PyMySQL (>=1.1.0)", "cloud-sql-python-connector[pg8000] (>=1.0.0,<2.0.0)", "cryptography (>=41.0.2)", "docstring-parser (>=0.15,<1.0)", "freezegun (>=0.3.12)", "hypothesis (>5.0.0,<6.148.4)", "jinja2 (>=3.0,<3.2)", "joblib (>=1.0.1)", "mock (>=1.0.1,<6.0.0)", "oracledb (>=3.1.1)", "pandas (<2.3.0)", "parameterized (>=0.7.1,<0.10.0)", "pg8000 (>=1.31.5)", "psycopg2-binary (>=2.8.5,<3.0)", "pyhamcrest (>=1.9,!=1.10.0,<3.0.0)", "pymilvus (>=2.5.10,<3.0.0)", "pytest (>=7.1.2,<9.0)", "pytest-timeout (>=2.1.0,<3)", "pytest-xdist (>=2.5.0,<4)", "python-tds (>=1.16.1)", "requests_mock (>=1.7,<2.0)", "scikit-learn (>=0.20.0,<1.8.0)", "sqlalchemy (>=1.3,<3.0)", "sqlalchemy-pytds (>=1.0.2)", "tenacity (>=8.0.0,<9)", "testcontainers[kafka,milvus,mysql] (>=4.0.0,<5.0.0)", "virtualenv-clone (>=0.5,<1.0)"]
+test = ["PyMySQL (>=1.1.0)", "cloud-sql-python-connector[pg8000] (>=1.0.0,<2.0.0)", "cryptography (>=41.0.2)", "docstring-parser (>=0.15,<1.0)", "freezegun (>=0.3.12)", "hypothesis (>5.0.0,<6.148.4)", "jinja2 (>=3.0,<3.2)", "joblib (>=1.0.1)", "mock (>=1.0.1,<6.0.0)", "oracledb (>=3.1.1)", "pandas (<2.3.0)", "parameterized (>=0.7.1,<0.10.0)", "pg8000 (>=1.31.5)", "psycopg2-binary (>=2.8.5,<3.0)", "pyhamcrest (>=1.9,!=1.10.0,<3.0.0)", "pytest (>=7.1.2,<9.0)", "pytest-timeout (>=2.1.0,<3)", "pytest-xdist (>=2.5.0,<4)", "python-tds (>=1.16.1)", "requests_mock (>=1.7,<2.0)", "scikit-learn (>=0.20.0,<1.8.0)", "sqlalchemy (>=1.3,<3.0)", "sqlalchemy-pytds (>=1.0.2)", "tenacity (>=8.0.0,<9)", "testcontainers[kafka,milvus,mysql] (>=4.0.0,<5.0.0)", "virtualenv-clone (>=0.5,<1.0)"]
 tfrecord = ["crcmod (>=1.7,<2.0)"]
 tft = ["dill", "tensorflow_transform (>=1.14.0,<1.15.0)"]
 torch = ["torch (>=1.9.0,<2.8.0)"]
@@ -700,18 +695,18 @@ css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "boto3"
-version = "1.42.70"
+version = "1.42.84"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "custom"]
 files = [
-    {file = "boto3-1.42.70-py3-none-any.whl", hash = "sha256:18a108c4d5df89a200b3949de0d39c0879b100c455e3229ea38275dd392db0f4"},
-    {file = "boto3-1.42.70.tar.gz", hash = "sha256:d060b0d83d2832e403671b9a895e73c3b025df8bb5896d89e401b0678705aac4"},
+    {file = "boto3-1.42.84-py3-none-any.whl", hash = "sha256:4d03ad3211832484037337292586f71f48707141288d9ac23049c04204f4ab03"},
+    {file = "boto3-1.42.84.tar.gz", hash = "sha256:6a84b3293a5d8b3adf827a54588e7dcffcf0a85410d7dadca615544f97d27579"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.70,<1.43.0"
+botocore = ">=1.42.84,<1.43.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.16.0,<0.17.0"
 
@@ -720,14 +715,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.70"
+version = "1.42.84"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "custom"]
 files = [
-    {file = "botocore-1.42.70-py3-none-any.whl", hash = "sha256:54ed9d25f05f810efd22b0dfda0bb9178df3ad8952b2e4359e05156c9321bd3c"},
-    {file = "botocore-1.42.70.tar.gz", hash = "sha256:9ee17553b7febd1a0c1253b3b62ab5d79607eb6163c8fb943470a8893c31d4fa"},
+    {file = "botocore-1.42.84-py3-none-any.whl", hash = "sha256:15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3"},
+    {file = "botocore-1.42.84.tar.gz", hash = "sha256:234064604c80d9272a5e9f6b3566d260bcaa053a5e05246db90d7eca1c2cf44b"},
 ]
 
 [package.dependencies]
@@ -984,153 +979,153 @@ test = ["pytest", "ruff"]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "custom", "docs"]
 files = [
-    {file = "charset_normalizer-3.4.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2e1d8ca8611099001949d1cdfaefc510cf0f212484fe7c565f735b68c78c3c95"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e25369dc110d58ddf29b949377a93e0716d72a24f62bad72b2b39f155949c1fd"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:259695e2ccc253feb2a016303543d691825e920917e31f894ca1a687982b1de4"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dda86aba335c902b6149a02a55b38e96287157e609200811837678214ba2b1db"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:4482481cb0572180b6fd976a4d5c72a30263e98564da68b86ec91f0fe35e8565"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39f5068d35621da2881271e5c3205125cc456f54e9030d3f723288c873a71bf9"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8bea55c4eef25b0b19a0337dc4e3f9a15b00d569c77211fa8cde38684f234fb7"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f0cdaecd4c953bfae0b6bb64910aaaca5a424ad9c72d85cb88417bb9814f7550"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:150b8ce8e830eb7ccb029ec9ca36022f756986aaaa7956aad6d9ec90089338c0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:e68c14b04827dd76dcbd1aeea9e604e3e4b78322d8faf2f8132c7138efa340a8"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:3778fd7d7cd04ae8f54651f4a7a0bd6e39a0cf20f801720a4c21d80e9b7ad6b0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dad6e0f2e481fffdcf776d10ebee25e0ef89f16d691f1e5dee4b586375fdc64b"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win32.whl", hash = "sha256:74a2e659c7ecbc73562e2a15e05039f1e22c75b7c7618b4b574a3ea9118d1557"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:aa9cccf4a44b9b62d8ba8b4dd06c649ba683e4bf04eea606d2e94cfc2d6ff4d6"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_arm64.whl", hash = "sha256:e985a16ff513596f217cee86c21371b8cd011c0f6f056d0920aa2d926c544058"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:659a1e1b500fac8f2779dd9e1570464e012f43e580371470b45277a27baa7532"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f61aa92e4aad0be58eb6eb4e0c21acf32cf8065f4b2cae5665da756c4ceef982"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f50498891691e0864dc3da965f340fada0771f6142a378083dc4608f4ea513e2"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf625105bb9eef28a56a943fec8c8a98aeb80e7d7db99bd3c388137e6eb2d237"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2bd9d128ef93637a5d7a6af25363cf5dec3fa21cf80e68055aad627f280e8afa"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:d08ec48f0a1c48d75d0356cea971921848fb620fdeba805b28f937e90691209f"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ed80ff870ca6de33f4d953fda4d55654b9a2b340ff39ab32fa3adbcd718f264"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:ab30e5e3e706e3063bc6de96b118688cb10396b70bb9864a430f67df98c61ecc"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:d5f5d1e9def3405f60e3ca8232d56f35c98fb7bf581efcc60051ebf53cb8b611"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:461598cd852bfa5a61b09cae2b1c02e2efcd166ee5516e243d540ac24bfa68a7"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:71be7e0e01753a89cf024abf7ecb6bca2c81738ead80d43004d9b5e3f1244e64"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:df01808ee470038c3f8dc4f48620df7225c49c2d6639e38f96e6d6ac6e6f7b0e"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win32.whl", hash = "sha256:69dd852c2f0ad631b8b60cfbe25a28c0058a894de5abb566619c205ce0550eae"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win_amd64.whl", hash = "sha256:517ad0e93394ac532745129ceabdf2696b609ec9f87863d337140317ebce1c14"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31215157227939b4fb3d740cd23fe27be0439afef67b785a1eb78a3ae69cba9e"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecbbd45615a6885fe3240eb9db73b9e62518b611850fdf8ab08bd56de7ad2b17"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c45a03a4c69820a399f1dda9e1d8fbf3562eda46e7720458180302021b08f778"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e8aeb10fcbe92767f0fa69ad5a72deca50d0dca07fbde97848997d778a50c9fe"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fae94be3d75f3e573c9a1b5402dc593de19377013c9a0e4285e3d402dd3a2a"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:2f7fdd9b6e6c529d6a2501a2d36b240109e78a8ceaef5687cfcfa2bbe671d297"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1d02209e06550bdaef34af58e041ad71b88e624f5d825519da3a3308e22687"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5f0687d796c05b1e28ab0d38a50e6309906ee09375dd3aff6a9c09dd6e8f4"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ee4ec14bc1680d6b0afab9aea2ef27e26d2024f18b24a2d7155a52b60da7e833"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d1a2ee9c1499fc8f86f4521f27a973c914b211ffa87322f4ee33bb35392da2c5"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:48696db7f18afb80a068821504296eb0787d9ce239b91ca15059d1d3eaacf13b"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4f41da960b196ea355357285ad1316a00099f22d0929fe168343b99b254729c9"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:802168e03fba8bbc5ce0d866d589e4b1ca751d06edee69f7f3a19c5a9fe6b597"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win32.whl", hash = "sha256:8761ac29b6c81574724322a554605608a9960769ea83d2c73e396f3df896ad54"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:1cf0a70018692f85172348fe06d3a4b63f94ecb055e13a00c644d368eb82e5b8"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_arm64.whl", hash = "sha256:3516bbb8d42169de9e61b8520cbeeeb716f12f4ecfe3fd30a9919aa16c806ca8"},
-    {file = "charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69"},
-    {file = "charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win32.whl", hash = "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"},
+    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
+    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
-    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+    {file = "click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"},
+    {file = "click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5"},
 ]
 
 [package.dependencies]
@@ -1610,61 +1605,61 @@ dev = ["black (==22.3.0)", "hypothesis (==6.60.0)", "numpy", "pytest (>=5.30)", 
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0"},
-    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82"},
-    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1"},
-    {file = "cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48"},
-    {file = "cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0"},
-    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826"},
-    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a"},
-    {file = "cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4"},
-    {file = "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d"},
-    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4"},
-    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9"},
-    {file = "cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72"},
-    {file = "cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257"},
-    {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
-    {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
 ]
 
 [package.dependencies]
@@ -1677,7 +1672,7 @@ nox = ["nox[uv] (>=2024.4.15)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -1786,7 +1781,7 @@ pyyaml = ">=6.0.3"
 type = "git"
 url = "https://github.com/ocean-ai-data-challenges/dc_leaderboard"
 reference = "main"
-resolved_reference = "09a5e6af01ede14deefc9efcc63f4838a103b1a2"
+resolved_reference = "a70cb3d6dfda2f9b50313b015180e4b289b424ca"
 
 [[package]]
 name = "debugpy"
@@ -2519,14 +2514,14 @@ files = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2026.3.0"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437"},
-    {file = "fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff"},
+    {file = "fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4"},
+    {file = "fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41"},
 ]
 
 [package.dependencies]
@@ -2633,216 +2628,155 @@ timezone = ["pytz"]
 
 [[package]]
 name = "grpcio"
-version = "1.65.5"
-description = "HTTP/2-based RPC framework"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "python_version <= \"3.12\""
-files = [
-    {file = "grpcio-1.65.5-cp310-cp310-linux_armv7l.whl", hash = "sha256:b67d450f1e008fedcd81e097a3a400a711d8be1a8b20f852a7b8a73fead50fe3"},
-    {file = "grpcio-1.65.5-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:a70a20eed87bba647a38bedd93b3ce7db64b3f0e8e0952315237f7f5ca97b02d"},
-    {file = "grpcio-1.65.5-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:f79c87c114bf37adf408026b9e2e333fe9ff31dfc9648f6f80776c513145c813"},
-    {file = "grpcio-1.65.5-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f17f9fa2d947dbfaca01b3ab2c62eefa8240131fdc67b924eb42ce6032e3e5c1"},
-    {file = "grpcio-1.65.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32d60e18ff7c34fe3f6db3d35ad5c6dc99f5b43ff3982cb26fad4174462d10b1"},
-    {file = "grpcio-1.65.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fe6505376f5b00bb008e4e1418152e3ad3d954b629da286c7913ff3cfc0ff740"},
-    {file = "grpcio-1.65.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:33158e56c6378063923c417e9fbdb28660b6e0e2835af42e67f5a7793f587af7"},
-    {file = "grpcio-1.65.5-cp310-cp310-win32.whl", hash = "sha256:1cbc208edb9acf1cc339396a1a36b83796939be52f34e591c90292045b579fbf"},
-    {file = "grpcio-1.65.5-cp310-cp310-win_amd64.whl", hash = "sha256:bc74f3f745c37e2c5685c9d2a2d5a94de00f286963f5213f763ae137bf4f2358"},
-    {file = "grpcio-1.65.5-cp311-cp311-linux_armv7l.whl", hash = "sha256:3207ae60d07e5282c134b6e02f9271a2cb523c6d7a346c6315211fe2bf8d61ed"},
-    {file = "grpcio-1.65.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a2f80510f99f82d4eb825849c486df703f50652cea21c189eacc2b84f2bde764"},
-    {file = "grpcio-1.65.5-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:a80e9a5e3f93c54f5eb82a3825ea1fc4965b2fa0026db2abfecb139a5c4ecdf1"},
-    {file = "grpcio-1.65.5-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b2944390a496567de9e70418f3742b477d85d8ca065afa90432edc91b4bb8ad"},
-    {file = "grpcio-1.65.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3655139d7be213c32c79ef6fb2367cae28e56ef68e39b1961c43214b457f257"},
-    {file = "grpcio-1.65.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05f02d68fc720e085f061b704ee653b181e6d5abfe315daef085719728d3d1fd"},
-    {file = "grpcio-1.65.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1c4caafe71aef4dabf53274bbf4affd6df651e9f80beedd6b8e08ff438ed3260"},
-    {file = "grpcio-1.65.5-cp311-cp311-win32.whl", hash = "sha256:84c901cdec16a092099f251ef3360d15e29ef59772150fa261d94573612539b5"},
-    {file = "grpcio-1.65.5-cp311-cp311-win_amd64.whl", hash = "sha256:11f8b16121768c1cb99d7dcb84e01510e60e6a206bf9123e134118802486f035"},
-    {file = "grpcio-1.65.5-cp312-cp312-linux_armv7l.whl", hash = "sha256:ee6ed64a27588a2c94e8fa84fe8f3b5c89427d4d69c37690903d428ec61ca7e4"},
-    {file = "grpcio-1.65.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:76991b7a6fb98630a3328839755181ce7c1aa2b1842aa085fd4198f0e5198960"},
-    {file = "grpcio-1.65.5-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:89c00a18801b1ed9cc441e29b521c354725d4af38c127981f2c950c796a09b6e"},
-    {file = "grpcio-1.65.5-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:078038e150a897e5e402ed3d57f1d31ebf604cbed80f595bd281b5da40762a92"},
-    {file = "grpcio-1.65.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c97962720489ef31b5ad8a916e22bc31bba3664e063fb9f6702dce056d4aa61b"},
-    {file = "grpcio-1.65.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b8270b15b99781461b244f5c81d5c2bc9696ab9189fb5ff86c841417fb3b39fe"},
-    {file = "grpcio-1.65.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8e5c4c15ac3fe1eb68e46bc51e66ad29be887479f231f8237cf8416058bf0cc1"},
-    {file = "grpcio-1.65.5-cp312-cp312-win32.whl", hash = "sha256:f5b5970341359341d0e4c789da7568264b2a89cd976c05ea476036852b5950cd"},
-    {file = "grpcio-1.65.5-cp312-cp312-win_amd64.whl", hash = "sha256:238a625f391a1b9f5f069bdc5930f4fd71b74426bea52196fc7b83f51fa97d34"},
-    {file = "grpcio-1.65.5-cp38-cp38-linux_armv7l.whl", hash = "sha256:6c4e62bcf297a1568f627f39576dbfc27f1e5338a691c6dd5dd6b3979da51d1c"},
-    {file = "grpcio-1.65.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d7df567b67d16d4177835a68d3f767bbcbad04da9dfb52cbd19171f430c898bd"},
-    {file = "grpcio-1.65.5-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:b7ca419f1462390851eec395b2089aad1e49546b52d4e2c972ceb76da69b10f8"},
-    {file = "grpcio-1.65.5-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa36dd8496d3af0d40165252a669fa4f6fd2db4b4026b9a9411cbf060b9d6a15"},
-    {file = "grpcio-1.65.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a101696f9ece90a0829988ff72f1b1ea2358f3df035bdf6d675dd8b60c2c0894"},
-    {file = "grpcio-1.65.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2a6d8169812932feac514b420daffae8ab8e36f90f3122b94ae767e633296b17"},
-    {file = "grpcio-1.65.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:47d0aaaab82823f0aa6adea5184350b46e2252e13a42a942db84da5b733f2e05"},
-    {file = "grpcio-1.65.5-cp38-cp38-win32.whl", hash = "sha256:85ae8f8517d5bcc21fb07dbf791e94ed84cc28f84c903cdc2bd7eaeb437c8f45"},
-    {file = "grpcio-1.65.5-cp38-cp38-win_amd64.whl", hash = "sha256:770bd4bd721961f6dd8049bc27338564ba8739913f77c0f381a9815e465ff965"},
-    {file = "grpcio-1.65.5-cp39-cp39-linux_armv7l.whl", hash = "sha256:ab5ec837d8cee8dbce9ef6386125f119b231e4333cc6b6d57b6c5c7c82a72331"},
-    {file = "grpcio-1.65.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cabd706183ee08d8026a015af5819a0b3a8959bdc9d1f6fdacd1810f09200f2a"},
-    {file = "grpcio-1.65.5-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:ec71fc5b39821ad7d80db7473c8f8c2910f3382f0ddadfbcfc2c6c437107eb67"},
-    {file = "grpcio-1.65.5-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3a9e35bcb045e39d7cac30464c285389b9a816ac2067e4884ad2c02e709ef8e"},
-    {file = "grpcio-1.65.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d750e9330eb14236ca11b78d0c494eed13d6a95eb55472298f0e547c165ee324"},
-    {file = "grpcio-1.65.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2b91ce647b6307f25650872454a4d02a2801f26a475f90d0b91ed8110baae589"},
-    {file = "grpcio-1.65.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8da58ff80bc4556cf29bc03f5fff1f03b8387d6aaa7b852af9eb65b2cf833be4"},
-    {file = "grpcio-1.65.5-cp39-cp39-win32.whl", hash = "sha256:7a412959aa5f08c5ac04aa7b7c3c041f5e4298cadd4fcc2acff195b56d185ebc"},
-    {file = "grpcio-1.65.5-cp39-cp39-win_amd64.whl", hash = "sha256:55714ea852396ec9568f45f487639945ab674de83c12bea19d5ddbc3ae41ada3"},
-    {file = "grpcio-1.65.5.tar.gz", hash = "sha256:ec6f219fb5d677a522b0deaf43cea6697b16f338cb68d009e30930c4aa0d2209"},
-]
-
-[package.extras]
-protobuf = ["grpcio-tools (>=1.65.5)"]
-
-[[package]]
-name = "grpcio"
-version = "1.78.0"
+version = "1.80.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.13\""
 files = [
-    {file = "grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5"},
-    {file = "grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2"},
-    {file = "grpcio-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d"},
-    {file = "grpcio-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4c5533d03a6cbd7f56acfc9cfb44ea64f63d29091e40e44010d34178d392d7eb"},
-    {file = "grpcio-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff870aebe9a93a85283837801d35cd5f8814fe2ad01e606861a7fb47c762a2b7"},
-    {file = "grpcio-1.78.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:391e93548644e6b2726f1bb84ed60048d4bcc424ce5e4af0843d28ca0b754fec"},
-    {file = "grpcio-1.78.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:df2c8f3141f7cbd112a6ebbd760290b5849cda01884554f7c67acc14e7b1758a"},
-    {file = "grpcio-1.78.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bd8cb8026e5f5b50498a3c4f196f57f9db344dad829ffae16b82e4fdbaea2813"},
-    {file = "grpcio-1.78.0-cp310-cp310-win32.whl", hash = "sha256:f8dff3d9777e5d2703a962ee5c286c239bf0ba173877cc68dc02c17d042e29de"},
-    {file = "grpcio-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:94f95cf5d532d0e717eed4fc1810e8e6eded04621342ec54c89a7c2f14b581bf"},
-    {file = "grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6"},
-    {file = "grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e"},
-    {file = "grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911"},
-    {file = "grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e"},
-    {file = "grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303"},
-    {file = "grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04"},
-    {file = "grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec"},
-    {file = "grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074"},
-    {file = "grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856"},
-    {file = "grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558"},
-    {file = "grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97"},
-    {file = "grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e"},
-    {file = "grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996"},
-    {file = "grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7"},
-    {file = "grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9"},
-    {file = "grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383"},
-    {file = "grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6"},
-    {file = "grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce"},
-    {file = "grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68"},
-    {file = "grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e"},
-    {file = "grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b"},
-    {file = "grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a"},
-    {file = "grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84"},
-    {file = "grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb"},
-    {file = "grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5"},
-    {file = "grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9"},
-    {file = "grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702"},
-    {file = "grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20"},
-    {file = "grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670"},
-    {file = "grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4"},
-    {file = "grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e"},
-    {file = "grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f"},
-    {file = "grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724"},
-    {file = "grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b"},
-    {file = "grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7"},
-    {file = "grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452"},
-    {file = "grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127"},
-    {file = "grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65"},
-    {file = "grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c"},
-    {file = "grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb"},
-    {file = "grpcio-1.78.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:86f85dd7c947baa707078a236288a289044836d4b640962018ceb9cd1f899af5"},
-    {file = "grpcio-1.78.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:de8cb00d1483a412a06394b8303feec5dcb3b55f81d83aa216dbb6a0b86a94f5"},
-    {file = "grpcio-1.78.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e888474dee2f59ff68130f8a397792d8cb8e17e6b3434339657ba4ee90845a8c"},
-    {file = "grpcio-1.78.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:86ce2371bfd7f212cf60d8517e5e854475c2c43ce14aa910e136ace72c6db6c1"},
-    {file = "grpcio-1.78.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0c689c02947d636bc7fab3e30cc3a3445cca99c834dfb77cd4a6cabfc1c5597"},
-    {file = "grpcio-1.78.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ce7599575eeb25c0f4dc1be59cada6219f3b56176f799627f44088b21381a28a"},
-    {file = "grpcio-1.78.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:684083fd383e9dc04c794adb838d4faea08b291ce81f64ecd08e4577c7398adf"},
-    {file = "grpcio-1.78.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ab399ef5e3cd2a721b1038a0f3021001f19c5ab279f145e1146bb0b9f1b2b12c"},
-    {file = "grpcio-1.78.0-cp39-cp39-win32.whl", hash = "sha256:f3d6379493e18ad4d39537a82371c5281e153e963cecb13f953ebac155756525"},
-    {file = "grpcio-1.78.0-cp39-cp39-win_amd64.whl", hash = "sha256:5361a0630a7fdb58a6a97638ab70e1dae2893c4d08d7aba64ded28bb9e7a29df"},
-    {file = "grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5"},
+    {file = "grpcio-1.80.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:886457a7768e408cdce226ad1ca67d2958917d306523a0e21e1a2fdaa75c9c9c"},
+    {file = "grpcio-1.80.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7b641fc3f1dc647bfd80bd713addc68f6d145956f64677e56d9ebafc0bd72388"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33eb763f18f006dc7fee1e69831d38d23f5eccd15b2e0f92a13ee1d9242e5e02"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:52d143637e3872633fc7dd7c3c6a1c84e396b359f3a72e215f8bf69fd82084fc"},
+    {file = "grpcio-1.80.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c51bf8ac4575af2e0678bccfb07e47321fc7acb5049b4482832c5c195e04e13a"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:50a9871536d71c4fba24ee856abc03a87764570f0c457dd8db0b4018f379fed9"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a72d84ad0514db063e21887fbacd1fd7acb4d494a564cae22227cd45c7fbf199"},
+    {file = "grpcio-1.80.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f7691a6788ad9196872f95716df5bc643ebba13c97140b7a5ee5c8e75d1dea81"},
+    {file = "grpcio-1.80.0-cp310-cp310-win32.whl", hash = "sha256:46c2390b59d67f84e882694d489f5b45707c657832d7934859ceb8c33f467069"},
+    {file = "grpcio-1.80.0-cp310-cp310-win_amd64.whl", hash = "sha256:dc053420fc75749c961e2a4c906398d7c15725d36ccc04ae6d16093167223b58"},
+    {file = "grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a"},
+    {file = "grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21"},
+    {file = "grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106"},
+    {file = "grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6"},
+    {file = "grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440"},
+    {file = "grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9"},
+    {file = "grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0"},
+    {file = "grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921"},
+    {file = "grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f"},
+    {file = "grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f"},
+    {file = "grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193"},
+    {file = "grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff"},
+    {file = "grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad"},
+    {file = "grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6"},
+    {file = "grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7"},
+    {file = "grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7"},
+    {file = "grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294"},
+    {file = "grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50"},
+    {file = "grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e"},
+    {file = "grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14"},
+    {file = "grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f"},
+    {file = "grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e"},
+    {file = "grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae"},
+    {file = "grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f"},
+    {file = "grpcio-1.80.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:aacdfb4ed3eb919ca997504d27e03d5dba403c85130b8ed450308590a738f7a4"},
+    {file = "grpcio-1.80.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a361c20ec1ccd3c3953d20fb6d7b4125093bdd10dff44c5e2bbb39e58917cedc"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:43168871f170d1e4ed16ae03d10cd21efa29f190e710a624cee7e5ae07da6f4f"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1b97cd29a8eda100b559b455331c487a80915b6ea6bd91cf3e89836c4ee8d957"},
+    {file = "grpcio-1.80.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bac1d573dfa84ce59a5547073e28fa7326d53352adda6912e362da0b917fcef4"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4560cf0e86514595dbbd330cd65b7afad4b5c4b8c4905c041cfffa138d45e6fd"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec0a592e926071b4abad50c1495cd0d0d513324b3ff5e7267067c33ba27506e4"},
+    {file = "grpcio-1.80.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:deb10a1528473c11f72a0939eed36d83e847d7cbb63e8cc5611fb7a912d38614"},
+    {file = "grpcio-1.80.0-cp39-cp39-win32.whl", hash = "sha256:627fb7312171cdc52828bd6fac8d7028ff2a64b89f1957b6f3416caa2218d141"},
+    {file = "grpcio-1.80.0-cp39-cp39-win_amd64.whl", hash = "sha256:05d55e1798756282cddd52d56c896b3e7d673e3a8798c2f1cd05ba249a3bb4de"},
+    {file = "grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257"},
 ]
 
 [package.dependencies]
 typing-extensions = ">=4.12,<5.0"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.78.0)"]
+protobuf = ["grpcio-tools (>=1.80.0)"]
 
 [[package]]
 name = "grpcio-tools"
-version = "1.78.0"
+version = "1.80.0"
 description = "Protobuf code generator for gRPC"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version >= \"3.13\""
 files = [
-    {file = "grpcio_tools-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:ea64e38d1caa2b8468b08cb193f5a091d169b6dbfe1c7dac37d746651ab9d84e"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:4003fcd5cbb5d578b06176fd45883a72a8f9203152149b7c680ce28653ad9e3a"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe6b0081775394c61ec633c9ff5dbc18337100eabb2e946b5c83967fe43b2748"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:7e989ad2cd93db52d7f1a643ecaa156ac55bf0484f1007b485979ce8aef62022"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b874991797e96c41a37e563236c3317ed41b915eff25b292b202d6277d30da85"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:daa8c288b728228377aaf758925692fc6068939d9fa32f92ca13dedcbeb41f33"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:87e648759b06133199f4bc0c0053e3819f4ec3b900dc399e1097b6065db998b5"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f3d3ced52bfe39eba3d24f5a8fab4e12d071959384861b41f0c52ca5399d6920"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-win32.whl", hash = "sha256:4bb6ed690d417b821808796221bde079377dff98fdc850ac157ad2f26cda7a36"},
-    {file = "grpcio_tools-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c676d8342fd53bd85a5d5f0d070cd785f93bc040510014708ede6fcb32fada1"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:6a8b8b7b49f319d29dbcf507f62984fa382d1d10437d75c3f26db5f09c4ac0af"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d62cf3b68372b0c6d722a6165db41b976869811abeabc19c8522182978d8db10"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fa9056742efeaf89d5fe14198af71e5cbc4fbf155d547b89507e19d6025906c6"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e3191af125dcb705aa6bc3856ba81ba99b94121c1b6ebee152e66ea084672831"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:283239ddbb67ae83fac111c61b25d8527a1dbd355b377cbc8383b79f1329944d"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ac977508c0db15301ef36d6c79769ec1a6cc4e3bc75735afca7fe7e360cead3a"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4ff605e25652a0bd13aa8a73a09bc48669c68170902f5d2bf1468a57d5e78771"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0197d7b561c79be78ab93d0fe2836c8def470683df594bae3ac89dd8e5c821b2"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-win32.whl", hash = "sha256:28f71f591f7f39555863ced84fcc209cbf4454e85ef957232f43271ee99af577"},
-    {file = "grpcio_tools-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:5a6de495dabf86a3b40b9a7492994e1232b077af9d63080811838b781abbe4e8"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:9eb122da57d4cad7d339fc75483116f0113af99e8d2c67f3ef9cae7501d806e4"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:d0c501b8249940b886420e6935045c44cb818fa6f265f4c2b97d5cff9cb5e796"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:77e5aa2d2a7268d55b1b113f958264681ef1994c970f69d48db7d4683d040f57"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8e3c0b0e6ba5275322ba29a97bf890565a55f129f99a21b121145e9e93a22525"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975d4cb48694e20ebd78e1643e5f1cd94cdb6a3d38e677a8e84ae43665aa4790"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:553ff18c5d52807dedecf25045ae70bad7a3dbba0b27a9a3cdd9bcf0a1b7baec"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8c7f5e4af5a84d2e96c862b1a65e958a538237e268d5f8203a3a784340975b51"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:96183e2b44afc3f9a761e9d0f985c3b44e03e8bb98e626241a6cbfb3b6f7e88f"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-win32.whl", hash = "sha256:2250e8424c565a88573f7dc10659a0b92802e68c2a1d57e41872c9b88ccea7a6"},
-    {file = "grpcio_tools-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:217d1fa29de14d9c567d616ead7cb0fef33cde36010edff5a9390b00d52e5094"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:2d6de1cc23bdc1baafc23e201b1e48c617b8c1418b4d8e34cebf72141676e5fb"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2afeaad88040894c76656202ff832cb151bceb05c0e6907e539d129188b1e456"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33cc593735c93c03d63efe7a8ba25f3c66f16c52f0651910712490244facad72"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2921d7989c4d83b71f03130ab415fa4d66e6693b8b8a1fcbb7a1c67cff19b812"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e6a0df438e82c804c7b95e3f311c97c2f876dcc36376488d5b736b7bcf5a9b45"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e9c6070a9500798225191ef25d0055a15d2c01c9c8f2ee7b681fffa99c98c822"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:394e8b57d85370a62e5b0a4d64c96fcf7568345c345d8590c821814d227ecf1d"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3ef700293ab375e111a2909d87434ed0a0b086adf0ce67a8d9cf12ea7765e63"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-win32.whl", hash = "sha256:6993b960fec43a8d840ee5dc20247ef206c1a19587ea49fe5e6cc3d2a09c1585"},
-    {file = "grpcio_tools-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:275ce3c2978842a8cf9dd88dce954e836e590cf7029649ad5d1145b779039ed5"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:8b080d0d072e6032708a3a91731b808074d7ab02ca8fb9847b6a011fdce64cd9"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8c0ad8f8f133145cd7008b49cb611a5c6a9d89ab276c28afa17050516e801f79"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f8ea092a7de74c6359335d36f0674d939a3c7e1a550f4c2c9e80e0226de8fe4"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:da422985e0cac822b41822f43429c19ecb27c81ffe3126d0b74e77edec452608"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4fab1faa3fbcb246263e68da7a8177d73772283f9db063fb8008517480888d26"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dd9c094f73f734becae3f20f27d4944d3cd8fb68db7338ee6c58e62fc5c3d99f"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2ed51ce6b833068f6c580b73193fc2ec16468e6bc18354bc2f83a58721195a58"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:05803a5cdafe77c8bdf36aa660ad7a6a1d9e49bc59ce45c1bade2a4698826599"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-win32.whl", hash = "sha256:f7c722e9ce6f11149ac5bddd5056e70aaccfd8168e74e9d34d8b8b588c3f5c7c"},
-    {file = "grpcio_tools-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d58ade518b546120ec8f0a8e006fc8076ae5df151250ebd7e82e9b5e152c229"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:30b1eef2afb6f2c3deb94525d60aedfea807d4937b5e23ad72600e3f8cd1c768"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:c70b07b2610db3743d831700301eb17a9e1de2818d1f36ad53cb5b8b593a5749"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f6d53392eb0f758eaa9ecfa6f9aab1e1f3c9db117a4242c802a30363fdc404d2"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:638fa11b4731dce2c662f685c3be0489246e8d2306654eb26ebd71e6a24c4b70"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21b31c87cef35af124f1cfb105614725b462656d2684f59d05a6210266b17b9e"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b81b4cf356272512172a604d4467af9b373de69cd69e1ac163fb41f7dac33099"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:5c8ceb32cd818e40739529b3c3143a30c899c247db22a6275c4798dece9a4ae7"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1872d01f984c85ee49ce581fcaffbcc9c792692b4b5ebf9bba4358fc895c316a"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-win32.whl", hash = "sha256:4eff49de5f8f320ed2a69bbb6bfe512175b1762d736cfce28aca0129939f7252"},
-    {file = "grpcio_tools-1.78.0-cp39-cp39-win_amd64.whl", hash = "sha256:6ddf7e7a7d069e7287b9cb68937102efe1686e63117a162d01578ac2839b4acd"},
-    {file = "grpcio_tools-1.78.0.tar.gz", hash = "sha256:4b0dd86560274316e155d925158276f8564508193088bc43e20d3f5dff956b2b"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:727477b9afa4b53f5ec70cafb41c3965d893835e0d4ea9b542fe3d0d005602bf"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:85fe8d15f146c62cb76f38d963e256392d287442b9232717d30ae9e3bbda9bc3"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:95f0fffb5ca00519f3b602f938169b4dfa04b165e03258323965a9dfe8cc4d80"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:7a0106af212748823a6ebd8ffbd9043414216f47cae3835f3187de0a62c415d3"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:31fd01a4038b5dfc4ec79504a17061344f670f851833411717fef66920f13cd7"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:57da9e19607fac4a01c48ead333c0dd15d91ed38794dce1194eda308f73e2038"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:90968f751851abb8b145593609800fa70c837e1c93ba0792c480b1c8d8bc29ef"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b69dc5d6376ab43406304d1e2fc61ccf960b287d4325d77c3d45448c37a9d2da"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-win32.whl", hash = "sha256:3e8dcfebe34cb54df095de3d5871a4562a85a29f26d0f8bb41ee2c3dcfb11c3c"},
+    {file = "grpcio_tools-1.80.0-cp310-cp310-win_amd64.whl", hash = "sha256:fc622ed4ca400695f41c9eae3266276c6ba007e4c28164ce53b44e7ccc5e492b"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:1c43e5c768578fe0c6de3dbfaabe64af642951e1aa05c487cacedda63fa6c6c4"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a225348456575f3ac7851d8e23163195e76d2a905ee340cf73f33da62fba08aa"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a9396f02820d3f51c368c2c9dee15c55c77636c91be48a4d5c702e98d6fe0fdc"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:797c08460cae16b402326eac329aec720dccf45c9f9279b95a352792eb53cf0f"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1872a867eb6217de19edb70a4ce4a374ced9d94293533dfd42fa649713f55bf4"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db122ba5ee357e3bb14e8944d69bbebcbdae91d5eace29ed4df3edc53cbc6528"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ddefd48c227e6f4d640fe576fac5fb2c4a8898196f513604c8ec7671b3b3d421"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:970ec058fa469dd6dae6ebc687501c5da670d95dead75f62f5b0933dce2c9794"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-win32.whl", hash = "sha256:526b4402d47a0e9b31cd6087e42b7674784617916cc73c764e0bc35ed41b4ee5"},
+    {file = "grpcio_tools-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:ee101ecda7231770f6a5da1024a9a6ed587a7785f8fe23ab8283f4a1acb3ffe6"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:d19d5a8244311947b96f749c417b32d144641c6953f1164824579e1f0a51d040"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fb599a3dc89ed1bb24489a2724b2f6dd4cddbbf0f7bdd69c073477bab0dc7554"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:623ee31fc2ff7df9a987b4f3d139c30af17ce46a861ae0e25fb8c112daa32dd8"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b46570a68378539ee2b75a5a43202561f8d753c832798b1047099e3c551cf5d6"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51caf99c28999e7e0f97e9cea190c1405b7681a57bb2e0631205accd92b43fa4"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cdaa1c9aa8d3a87891a96700cadd29beec214711d6522818d207277f6452567c"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3399b5fd7b59bcffd59c6b9975a969d9f37a3c87f3e3d63c3a09c147907acb0d"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9c6abc08d3485b2aac99bb58afcd31dc6cd4316ce36cf263ff09cb6df15f287f"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-win32.whl", hash = "sha256:18c51e07652ac7386fcdbd11866f8d55a795de073337c12447b5805575339f74"},
+    {file = "grpcio_tools-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:ac6fdd42d5bb18f0d903a067e2825be172deff70cf197164b6f65676cb506c9b"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e7046837859bbfd10b01786056145480155c16b222c9e209215b68d3be13060e"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a447f28958a8fe84ff0d9d3d9473868feb27ee4a9c9c805e66f5b670121cec59"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:75f00450e08fe648ad8a1eeb25bc52219679d54cdd02f04dfdddc747309d83f6"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3db830eaff1f2c2797328f2fa86c9dcdbd7d81af573a68db81e27afa2182a611"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7982b5fe42f012686b667dda12916884de95c4b1c65ff64371fb7232a1474b23"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6451b3f4eb52d12c7f32d04bf8e0185f80521f3f088ad04b8d222b3a4819c71e"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:258bc30654a9a2236be4ca8e2ad443e2ac6db7c8cc20454d34cce60265922726"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:865a2b8e6334c838976ab02a322cbd55c863d2eaf3c1e1a0255883c63996772a"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-win32.whl", hash = "sha256:f760ac1722f33e774814c37b6aa0444143f612e85088ead7447a0e9cd306a1f1"},
+    {file = "grpcio_tools-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:7843b9ac6ff8ca508424d0dd968bd9a1a4559967e4a290f26be5bd6f04af2234"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:12f950470449dbeec78317dbc090add7a00eb6ca812af7b0538ab7441e0a42c3"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d3f9a376a29c9adf62bb56f7ff5bc81eb4abeaf53d1e7dde5015564832901a51"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ba1ffbf2cff71533615e2c5a138ed5569611eec9ae7f9c67b8898e127b54ac0"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:13f60f8d9397c514c6745a967d22b5c8c698347e88deebca1ff2e1b94555e450"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:88d77bad5dd3cd5e6f952c4ecdd0ee33e0c02ecfc2e4b0cbee3391ac19e0a431"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:017945c3e98a4ed1c4e21399781b4137fc08dfc1f802c8ace2e64ef52d32b142"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a33e265d4db803495007a6c623eafb0f6b9bb123ff4a0af89e44567dad809b88"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c129da370c5f85f569be2e545317dda786a60dd51d7deea29b03b0c05f6aac3"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-win32.whl", hash = "sha256:25742de5958ae4325249a37e724e7c0e5120f8e302a24a977ebd1737b48a5e97"},
+    {file = "grpcio_tools-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:bbf8eeef78fda1966f732f79c1c802fadd5cfd203d845d2af4d314d18569069c"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:4c615f3b5c6f7e8e0b06f60e3fa9cebf88372296255268db9e9a23e72bb698bf"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:3954b5d07ac19d752ee70c7d63ee0ba0f9a840c33e042decf355f04b1ff41d93"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9a765334d3080d147ecf7b8ab04900e56108f6457dde0a3ba7f68c270f9d6efc"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:c18def9c38d36767946932d2cc7baf39dcae5fea5a02843ea34399871f981a09"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4534022e4d5dd3d7d2183ff5846bf950cbaf889af0ea5290f94212001f7cad84"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1816e8e512402ed0b3fe4a336aaff14f9cb42455aa88fa86f754d53973668bd6"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e3b6d09f87eb87a8cab58f7e99cae3551467f51b2bcbab17a2fe931e94e7efef"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6c6ce08167fd77fa057dc44fea8501c66d108eeef536073dba55c8fd3684c7a9"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-win32.whl", hash = "sha256:5de4eb2d08bddeee28265c10369934b2d23b8c4acc39d419ee6a58afe34d754f"},
+    {file = "grpcio_tools-1.80.0-cp39-cp39-win_amd64.whl", hash = "sha256:6a35a73042dc4bbcdd7aafc141ee9966c8ae97bf4b9f0f49e10e3e1aa54139ac"},
+    {file = "grpcio_tools-1.80.0.tar.gz", hash = "sha256:26052b19c6ce0dcf52d1024496aea3e2bdfa864159f06dc7b97b22d041a94b26"},
 ]
 
 [package.dependencies]
-grpcio = ">=1.78.0"
+grpcio = ">=1.80.0"
 protobuf = ">=6.31.1,<7.0.0"
 setuptools = ">=77.0.1"
 
@@ -3027,38 +2961,38 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hf-xet"
-version = "1.4.2"
+version = "1.4.3"
 description = "Fast transfer of large files with the Hugging Face Hub."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
 files = [
-    {file = "hf_xet-1.4.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ac8202ae1e664b2c15cdfc7298cbb25e80301ae596d602ef7870099a126fcad4"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6d2f8ee39fa9fba9af929f8c0d0482f8ee6e209179ad14a909b6ad78ffcb7c81"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4642a6cf249c09da8c1f87fe50b24b2a3450b235bf8adb55700b52f0ea6e2eb6"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:769431385e746c92dc05492dde6f687d304584b89c33d79def8367ace06cb555"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c9dd1c1bc4cc56168f81939b0e05b4c36dd2d28c13dc1364b17af89aa0082496"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:fca58a2ae4e6f6755cc971ac6fcdf777ea9284d7e540e350bb000813b9a3008d"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:163aab46854ccae0ab6a786f8edecbbfbaa38fcaa0184db6feceebf7000c93c0"},
-    {file = "hf_xet-1.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:09b138422ecbe50fd0c84d4da5ff537d27d487d3607183cd10e3e53f05188e82"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:949dcf88b484bb9d9276ca83f6599e4aa03d493c08fc168c124ad10b2e6f75d7"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:41659966020d59eb9559c57de2cde8128b706a26a64c60f0531fa2318f409418"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c588e21d80010119458dd5d02a69093f0d115d84e3467efe71ffb2c67c19146"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a296744d771a8621ad1d50c098d7ab975d599800dae6d48528ba3944e5001ba0"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f563f7efe49588b7d0629d18d36f46d1658fe7e08dce3fa3d6526e1c98315e2d"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5b2e0132c56d7ee1bf55bdb638c4b62e7106f6ac74f0b786fed499d5548c5570"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:2f45c712c2fa1215713db10df6ac84b49d0e1c393465440e9cb1de73ecf7bbf6"},
-    {file = "hf_xet-1.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6d53df40616f7168abfccff100d232e9d460583b9d86fa4912c24845f192f2b8"},
-    {file = "hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5"},
-    {file = "hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a"},
-    {file = "hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c"},
-    {file = "hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271"},
-    {file = "hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2"},
-    {file = "hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04"},
-    {file = "hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f"},
-    {file = "hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87"},
-    {file = "hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b"},
+    {file = "hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07"},
+    {file = "hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075"},
+    {file = "hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025"},
+    {file = "hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583"},
+    {file = "hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08"},
+    {file = "hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f"},
+    {file = "hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac"},
+    {file = "hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba"},
+    {file = "hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021"},
+    {file = "hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47"},
+    {file = "hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113"},
 ]
 
 [package.extras]
@@ -3100,18 +3034,18 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httplib2"
-version = "0.22.0"
+version = "0.31.2"
 description = "A comprehensive HTTP client library."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc"},
-    {file = "httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"},
+    {file = "httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349"},
+    {file = "httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24"},
 ]
 
 [package.dependencies]
-pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
+pyparsing = ">=3.1,<4"
 
 [[package]]
 name = "httpx"
@@ -3140,20 +3074,20 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "1.7.2"
+version = "1.10.1"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
-python-versions = ">=3.9.0"
+python-versions = ">=3.10.0"
 groups = ["main"]
 files = [
-    {file = "huggingface_hub-1.7.2-py3-none-any.whl", hash = "sha256:288f33a0a17b2a73a1359e2a5fd28d1becb2c121748c6173ab8643fb342c850e"},
-    {file = "huggingface_hub-1.7.2.tar.gz", hash = "sha256:7f7e294e9bbb822e025bdb2ada025fa4344d978175a7f78e824d86e35f7ab43b"},
+    {file = "huggingface_hub-1.10.1-py3-none-any.whl", hash = "sha256:6b981107a62fbe68c74374418983399c632e35786dcd14642a9f2972633c8b5a"},
+    {file = "huggingface_hub-1.10.1.tar.gz", hash = "sha256:696c53cf9c2ac9befbfb5dd41d05392a031c69fc6930d1ed9671debd405b6fff"},
 ]
 
 [package.dependencies]
 filelock = ">=3.10.0"
 fsspec = ">=2023.5.0"
-hf-xet = {version = ">=1.4.2,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
+hf-xet = {version = ">=1.4.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
 httpx = ">=0.23.0,<1"
 packaging = ">=20.9"
 pyyaml = ">=5.1"
@@ -3165,7 +3099,8 @@ typing-extensions = ">=4.1.0"
 all = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 dev = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
 fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
-hf-xet = ["hf-xet (>=1.4.2,<2.0.0)"]
+gradio = ["gradio (>=5.0.0)", "requests"]
+hf-xet = ["hf-xet (>=1.4.3,<2.0.0)"]
 mcp = ["mcp (>=1.8.0)"]
 oauth = ["authlib (>=1.3.2)", "fastapi", "httpx", "itsdangerous"]
 quality = ["libcst (>=1.4.0)", "mypy (==1.15.0)", "ruff (>=0.9.0)", "ty"]
@@ -3256,23 +3191,23 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "importlib-resources"
-version = "6.5.2"
+version = "7.0.0"
 description = "Read resources from Python packages"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec"},
-    {file = "importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c"},
+    {file = "importlib_resources-7.0.0-py3-none-any.whl", hash = "sha256:bba0dbad6a723061fb617707522bb4438e1690855640704fba115eccec7abb40"},
+    {file = "importlib_resources-7.0.0.tar.gz", hash = "sha256:ccb3c88c71b22528f9e8f2ccf46493f83496b93002fe0faeaefd90461c642585"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "iniconfig"
@@ -3322,15 +3257,15 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0,<10)", "pytest-asyn
 
 [[package]]
 name = "ipython"
-version = "9.10.0"
+version = "9.10.1"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.11"
 groups = ["custom"]
 markers = "python_version == \"3.11\""
 files = [
-    {file = "ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d"},
-    {file = "ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77"},
+    {file = "ipython-9.10.1-py3-none-any.whl", hash = "sha256:82d18ae9fb9164ded080c71ef92a182ee35ee7db2395f67616034bebb020a232"},
+    {file = "ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4"},
 ]
 
 [package.dependencies]
@@ -3356,15 +3291,15 @@ test-extra = ["curio", "ipykernel (>6.30)", "ipython[matplotlib]", "ipython[test
 
 [[package]]
 name = "ipython"
-version = "9.11.0"
+version = "9.12.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.12"
 groups = ["custom"]
 markers = "python_version >= \"3.12\""
 files = [
-    {file = "ipython-9.11.0-py3-none-any.whl", hash = "sha256:6922d5bcf944c6e525a76a0a304451b60a2b6f875e86656d8bc2dfda5d710e19"},
-    {file = "ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667"},
+    {file = "ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d"},
+    {file = "ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4"},
 ]
 
 [package.dependencies]
@@ -3502,25 +3437,26 @@ files = [
 
 [[package]]
 name = "json5"
-version = "0.13.0"
+version = "0.14.0"
 description = "A Python implementation of the JSON5 data format."
 optional = false
 python-versions = ">=3.8.0"
 groups = ["custom"]
 files = [
-    {file = "json5-0.13.0-py3-none-any.whl", hash = "sha256:9a08e1dd65f6a4d4c6fa82d216cf2477349ec2346a38fd70cc11d2557499fbcc"},
-    {file = "json5-0.13.0.tar.gz", hash = "sha256:b1edf8d487721c0bf64d83c28e91280781f6e21f4a797d3261c7c828d4c165bf"},
+    {file = "json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a"},
+    {file = "json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb"},
 ]
 
 [[package]]
 name = "jsonargparse"
-version = "4.47.0"
+version = "4.48.0"
 description = "Minimal effort CLIs derived from type hints and parse from command line, config files and environment variables."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jsonargparse-4.47.0-py3-none-any.whl", hash = "sha256:b038671662c1073b4a7045aa29c868e8485abe81c09ffc6716e6deff31c3cf25"},
+    {file = "jsonargparse-4.48.0-py3-none-any.whl", hash = "sha256:c6a92fd71eb256437371750bb11f436b9c3294da2535f1b0406346816f04be16"},
+    {file = "jsonargparse-4.48.0.tar.gz", hash = "sha256:128f0897951190a08820c282b92408e2e9a508ef6d439f02bdb87244171e77d8"},
 ]
 
 [package.dependencies]
@@ -3529,7 +3465,7 @@ PyYAML = ">=3.13"
 typeshed-client = {version = ">=2.8.2", optional = true, markers = "extra == \"signatures\""}
 
 [package.extras]
-all = ["jsonargparse[fsspec]", "jsonargparse[jsonnet]", "jsonargparse[jsonschema]", "jsonargparse[omegaconf]", "jsonargparse[reconplogger]", "jsonargparse[ruamel]", "jsonargparse[signatures]", "jsonargparse[toml]", "jsonargparse[typing-extensions]", "jsonargparse[urls]"]
+all = ["jsonargparse[fsspec]", "jsonargparse[jsonnet]", "jsonargparse[jsonschema]", "jsonargparse[omegaconf]", "jsonargparse[ruamel]", "jsonargparse[signatures]", "jsonargparse[toml]", "jsonargparse[typing-extensions]", "jsonargparse[urls]"]
 argcomplete = ["argcomplete (>=3.5.1)"]
 coverage = ["jsonargparse[test-no-urls]", "pytest-cov (>=4.0.0)"]
 dev = ["build (>=0.10.0)", "jsonargparse[coverage]", "jsonargparse[doc]", "jsonargparse[test]", "pre-commit (>=2.19.0)", "tox (>=3.25.0)"]
@@ -3539,7 +3475,6 @@ jsonnet = ["jsonnet (>=0.21.0)"]
 jsonschema = ["jsonschema (>=3.2.0)"]
 maintainer = ["bump2version (>=0.5.11)", "twine (>=4.0.2)"]
 omegaconf = ["omegaconf (>=2.1.1)"]
-reconplogger = ["reconplogger (>=4.4.0)"]
 ruamel = ["ruamel.yaml (>=0.18.15)"]
 ruyaml = ["jsonargparse[ruamel]"]
 shtab = ["shtab (>=1.7.1)"]
@@ -3745,14 +3680,14 @@ test = ["click", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=0.19.0)", "p
 
 [[package]]
 name = "jupyter-lsp"
-version = "2.3.0"
+version = "2.3.1"
 description = "Multi-Language Server WebSocket proxy for Jupyter Notebook/Lab server"
 optional = false
 python-versions = ">=3.8"
 groups = ["custom"]
 files = [
-    {file = "jupyter_lsp-2.3.0-py3-none-any.whl", hash = "sha256:e914a3cb2addf48b1c7710914771aaf1819d46b2e5a79b0f917b5478ec93f34f"},
-    {file = "jupyter_lsp-2.3.0.tar.gz", hash = "sha256:458aa59339dc868fb784d73364f17dbce8836e906cd75fd471a325cba02e0245"},
+    {file = "jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81"},
+    {file = "jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6"},
 ]
 
 [package.dependencies]
@@ -4156,115 +4091,115 @@ regex = ["regex"]
 
 [[package]]
 name = "librt"
-version = "0.8.1"
+version = "0.9.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "librt-0.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:81fd938344fecb9373ba1b155968c8a329491d2ce38e7ddb76f30ffb938f12dc"},
-    {file = "librt-0.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5db05697c82b3a2ec53f6e72b2ed373132b0c2e05135f0696784e97d7f5d48e7"},
-    {file = "librt-0.8.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d56bc4011975f7460bea7b33e1ff425d2f1adf419935ff6707273c77f8a4ada6"},
-    {file = "librt-0.8.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdc0f588ff4b663ea96c26d2a230c525c6fc62b28314edaaaca8ed5af931ad0"},
-    {file = "librt-0.8.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c2b54ff6717a7a563b72627990bec60d8029df17df423f0ed37d56a17a176b"},
-    {file = "librt-0.8.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8f1125e6bbf2f1657d9a2f3ccc4a2c9b0c8b176965bb565dd4d86be67eddb4b6"},
-    {file = "librt-0.8.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8f4bb453f408137d7581be309b2fbc6868a80e7ef60c88e689078ee3a296ae71"},
-    {file = "librt-0.8.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c336d61d2fe74a3195edc1646d53ff1cddd3a9600b09fa6ab75e5514ba4862a7"},
-    {file = "librt-0.8.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eb5656019db7c4deacf0c1a55a898c5bb8f989be904597fcb5232a2f4828fa05"},
-    {file = "librt-0.8.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c25d9e338d5bed46c1632f851babf3d13c78f49a225462017cf5e11e845c5891"},
-    {file = "librt-0.8.1-cp310-cp310-win32.whl", hash = "sha256:aaab0e307e344cb28d800957ef3ec16605146ef0e59e059a60a176d19543d1b7"},
-    {file = "librt-0.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:56e04c14b696300d47b3bc5f1d10a00e86ae978886d0cee14e5714fafb5df5d2"},
-    {file = "librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd"},
-    {file = "librt-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b4350b13cc0e6f5bec8fa7caf29a8fb8cdc051a3bae45cfbfd7ce64f009965"},
-    {file = "librt-0.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ac1e7817fd0ed3d14fd7c5df91daed84c48e4c2a11ee99c0547f9f62fdae13da"},
-    {file = "librt-0.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:747328be0c5b7075cde86a0e09d7a9196029800ba75a1689332348e998fb85c0"},
-    {file = "librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0af2bd2bc204fa27f3d6711d0f360e6b8c684a035206257a81673ab924aa11e"},
-    {file = "librt-0.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d480de377f5b687b6b1bc0c0407426da556e2a757633cc7e4d2e1a057aa688f3"},
-    {file = "librt-0.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d0ee06b5b5291f609ddb37b9750985b27bc567791bc87c76a569b3feed8481ac"},
-    {file = "librt-0.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9e2c6f77b9ad48ce5603b83b7da9ee3e36b3ab425353f695cba13200c5d96596"},
-    {file = "librt-0.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:439352ba9373f11cb8e1933da194dcc6206daf779ff8df0ed69c5e39113e6a99"},
-    {file = "librt-0.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82210adabbc331dbb65d7868b105185464ef13f56f7f76688565ad79f648b0fe"},
-    {file = "librt-0.8.1-cp311-cp311-win32.whl", hash = "sha256:52c224e14614b750c0a6d97368e16804a98c684657c7518752c356834fff83bb"},
-    {file = "librt-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:c00e5c884f528c9932d278d5c9cbbea38a6b81eb62c02e06ae53751a83a4d52b"},
-    {file = "librt-0.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:f7cdf7f26c2286ffb02e46d7bac56c94655540b26347673bea15fa52a6af17e9"},
-    {file = "librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a"},
-    {file = "librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9"},
-    {file = "librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb"},
-    {file = "librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d"},
-    {file = "librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7"},
-    {file = "librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440"},
-    {file = "librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9"},
-    {file = "librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972"},
-    {file = "librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921"},
-    {file = "librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0"},
-    {file = "librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a"},
-    {file = "librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444"},
-    {file = "librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d"},
-    {file = "librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35"},
-    {file = "librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583"},
-    {file = "librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c"},
-    {file = "librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04"},
-    {file = "librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363"},
-    {file = "librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0"},
-    {file = "librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012"},
-    {file = "librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb"},
-    {file = "librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b"},
-    {file = "librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d"},
-    {file = "librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a"},
-    {file = "librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79"},
-    {file = "librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0"},
-    {file = "librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f"},
-    {file = "librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c"},
-    {file = "librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc"},
-    {file = "librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c"},
-    {file = "librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3"},
-    {file = "librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14"},
-    {file = "librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7"},
-    {file = "librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6"},
-    {file = "librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071"},
-    {file = "librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78"},
-    {file = "librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023"},
-    {file = "librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730"},
-    {file = "librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3"},
-    {file = "librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1"},
-    {file = "librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee"},
-    {file = "librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7"},
-    {file = "librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040"},
-    {file = "librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e"},
-    {file = "librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732"},
-    {file = "librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624"},
-    {file = "librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4"},
-    {file = "librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382"},
-    {file = "librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994"},
-    {file = "librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a"},
-    {file = "librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4"},
-    {file = "librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61"},
-    {file = "librt-0.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3dff3d3ca8db20e783b1bc7de49c0a2ab0b8387f31236d6a026597d07fcd68ac"},
-    {file = "librt-0.8.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:08eec3a1fc435f0d09c87b6bf1ec798986a3544f446b864e4099633a56fcd9ed"},
-    {file = "librt-0.8.1-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e3f0a41487fd5fad7e760b9e8a90e251e27c2816fbc2cff36a22a0e6bcbbd9dd"},
-    {file = "librt-0.8.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bacdb58d9939d95cc557b4dbaa86527c9db2ac1ed76a18bc8d26f6dc8647d851"},
-    {file = "librt-0.8.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d7ab1f01aa753188605b09a51faa44a3327400b00b8cce424c71910fc0a128"},
-    {file = "librt-0.8.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4998009e7cb9e896569f4be7004f09d0ed70d386fa99d42b6d363f6d200501ac"},
-    {file = "librt-0.8.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2cc68eeeef5e906839c7bb0815748b5b0a974ec27125beefc0f942715785b551"},
-    {file = "librt-0.8.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0bf69d79a23f4f40b8673a947a234baeeb133b5078b483b7297c5916539cf5d5"},
-    {file = "librt-0.8.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:22b46eabd76c1986ee7d231b0765ad387d7673bbd996aa0d0d054b38ac65d8f6"},
-    {file = "librt-0.8.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:237796479f4d0637d6b9cbcb926ff424a97735e68ade6facf402df4ec93375ed"},
-    {file = "librt-0.8.1-cp39-cp39-win32.whl", hash = "sha256:4beb04b8c66c6ae62f8c1e0b2f097c1ebad9295c929a8d5286c05eae7c2fc7dc"},
-    {file = "librt-0.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:64548cde61b692dc0dc379f4b5f59a2f582c2ebe7890d09c1ae3b9e66fa015b7"},
-    {file = "librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73"},
+    {file = "librt-0.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f8e12706dcb8ff6b3ed57514a19e45c49ad00bcd423e87b2b2e4b5f64578443"},
+    {file = "librt-0.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e3dda8345307fd7306db0ed0cb109a63a2c85ba780eb9dc2d09b2049a931f9c"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:de7dac64e3eb832ffc7b840eb8f52f76420cde1b845be51b2a0f6b870890645e"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22a904cbdb678f7cb348c90d543d3c52f581663d687992fee47fd566dcbf5285"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:224b9727eb8bc188bc3bcf29d969dba0cd61b01d9bac80c41575520cc4baabb2"},
+    {file = "librt-0.9.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e94cbc6ad9a6aeea46d775cbb11f361022f778a9cc8cc90af653d3a594b057ce"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7bc30ad339f4e1a01d4917d645e522a0bc0030644d8973f6346397c93ba1503f"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:56d65b583cf43b8cf4c8fbe1e1da20fa3076cc32a1149a141507af1062718236"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0a1be03168b2691ba61927e299b352a6315189199ca18a57b733f86cb3cc8d38"},
+    {file = "librt-0.9.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:63c12efcd160e1d14da11af0c46c0217473e1e0d2ae1acbccc83f561ea4c2a7b"},
+    {file = "librt-0.9.0-cp310-cp310-win32.whl", hash = "sha256:e9002e98dcb1c0a66723592520decd86238ddcef168b37ff6cfb559200b4b774"},
+    {file = "librt-0.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9fcb461fbf70654a52a7cc670e606f04449e2374c199b1825f754e16dacfedd8"},
+    {file = "librt-0.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:90904fac73c478f4b83f4ed96c99c8208b75e6f9a8a1910548f69a00f1eaa671"},
+    {file = "librt-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789fff71757facc0738e8d89e3b84e4f0251c1c975e85e81b152cdaca927cc2d"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1bf465d1e5b0a27713862441f6467b5ab76385f4ecf8f1f3a44f8aa3c695b4b6"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f819e0c6413e259a17a7c0d49f97f405abadd3c2a316a3b46c6440b7dbbedbb1"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0785c2fb4a81e1aece366aa3e2e039f4a4d7d21aaaded5227d7f3c703427882"},
+    {file = "librt-0.9.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80b25c7b570a86c03b5da69e665809deb39265476e8e21d96a9328f9762f9990"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d4d16b608a1c43d7e33142099a75cd93af482dadce0bf82421e91cad077157f4"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:194fc1a32e1e21fe809d38b5faea66cc65eaa00217c8901fbdb99866938adbdb"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8c6bc1384d9738781cfd41d09ad7f6e8af13cfea2c75ece6bd6d2566cdea2076"},
+    {file = "librt-0.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15cb151e52a044f06e54ac7f7b47adbfc89b5c8e2b63e1175a9d587c43e8942a"},
+    {file = "librt-0.9.0-cp311-cp311-win32.whl", hash = "sha256:f100bfe2acf8a3689af9d0cc660d89f17286c9c795f9f18f7b62dd1a6b247ae6"},
+    {file = "librt-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:0b73e4266307e51c95e09c0750b7ec383c561d2e97d58e473f6f6a209952fbb8"},
+    {file = "librt-0.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc5518873822d2faa8ebdd2c1a4d7c8ef47b01a058495ab7924cb65bdbf5fc9a"},
+    {file = "librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4"},
+    {file = "librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2"},
+    {file = "librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8"},
+    {file = "librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f"},
+    {file = "librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f"},
+    {file = "librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745"},
+    {file = "librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9"},
+    {file = "librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e"},
+    {file = "librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11"},
+    {file = "librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2"},
+    {file = "librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d"},
+    {file = "librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd"},
+    {file = "librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519"},
+    {file = "librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5"},
+    {file = "librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb"},
+    {file = "librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f"},
+    {file = "librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b"},
+    {file = "librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b"},
+    {file = "librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9"},
+    {file = "librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e"},
+    {file = "librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f"},
+    {file = "librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4"},
+    {file = "librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938"},
+    {file = "librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c"},
+    {file = "librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15"},
+    {file = "librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40"},
+    {file = "librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118"},
+    {file = "librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61"},
+    {file = "librt-0.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5112c2fb7c2eefefaeaf5c97fec81343ef44ee86a30dcfaa8223822fba6467b4"},
+    {file = "librt-0.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a81eea9b999b985e4bacc650c4312805ea7008fd5e45e1bf221310176a7bcb3a"},
+    {file = "librt-0.9.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eea1b54943475f51698f85fa230c65ccac769f1e603b981be060ac5763d90927"},
+    {file = "librt-0.9.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:81107843ed1836874b46b310f9b1816abcb89912af627868522461c3b7333c0f"},
+    {file = "librt-0.9.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa95738a68cedd3a6f5492feddc513e2e166b50602958139e47bbdd82da0f5a7"},
+    {file = "librt-0.9.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6788207daa0c19955d2b668f3294a368d19f67d9b5f274553fd073c1260cbb9f"},
+    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f48c963a76d71b9d7927eb817b543d0dccd52ab6648b99d37bd54f4cd475d856"},
+    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:42ff8a962554c350d4a83cf47d9b7b78b0e6ff7943e87df7cdfc97c07f3c016f"},
+    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:657f8ba7b9eaaa82759a104137aed2a3ef7bc46ccfd43e0d89b04005b3e0a4cc"},
+    {file = "librt-0.9.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2d03fa4fd277a7974c1978c92c374c57f44edeee163d147b477b143446ad1bf6"},
+    {file = "librt-0.9.0-cp39-cp39-win32.whl", hash = "sha256:d9da80e5b04acce03ced8ba6479a71c2a2edf535c2acc0d09c80d2f80f3bad15"},
+    {file = "librt-0.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:54d412e47c21b85865676ed0724e37a89e9593c2eee1e7367adf85bfad56ffb1"},
+    {file = "librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d"},
 ]
 
 [[package]]
 name = "lightly"
-version = "1.5.22"
+version = "1.5.23"
 description = "A deep learning package for self-supervised learning"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "lightly-1.5.22-py3-none-any.whl", hash = "sha256:58694433dd85ec371cb532dba3fea9465009d36e4afac67e53dbf464dba69e2a"},
-    {file = "lightly-1.5.22.tar.gz", hash = "sha256:7bb8939976ea5e8fabb20d049812700d51e44f6461f15510a784afd1252a3dbd"},
+    {file = "lightly-1.5.23-py3-none-any.whl", hash = "sha256:9f5bbe53bdca155ad941bd38c5d15b80d1a772dba2e5f9a2d56ee295c7e38024"},
+    {file = "lightly-1.5.23.tar.gz", hash = "sha256:00737c90f074012f6c407f9067c88d94c3fc570b62e462af2a55519f04b5af9a"},
 ]
 
 [package.dependencies]
@@ -4290,7 +4225,7 @@ matplotlib = ["matplotlib (>=3)"]
 minimal = ["pytorch_lightning (>=1.6)", "torch (>=1.10.0)", "torchvision (>=0.11.0)"]
 openapi = ["aenum (>=3.1.11)", "pydantic (>=1.10.5)", "python_dateutil (>=2.5.3)", "setuptools (>=21.0.0)", "urllib3 (>=1.25.3)"]
 timm = ["timm (>=0.9.9)"]
-video = ["av (>=8.0.3)"]
+video = ["av (>=8.0.3) ; python_version >= \"3.8\""]
 
 [[package]]
 name = "lightly-utils"
@@ -4375,33 +4310,37 @@ typing = ["mypy (>=1.0.0)", "types-setuptools"]
 
 [[package]]
 name = "llvmlite"
-version = "0.46.0"
+version = "0.47.0"
 description = "lightweight wrapper around basic LLVM functionality"
 optional = false
 python-versions = ">=3.10"
 groups = ["custom"]
 files = [
-    {file = "llvmlite-0.46.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4323177e936d61ae0f73e653e2e614284d97d14d5dd12579adc92b6c2b0597b0"},
-    {file = "llvmlite-0.46.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a2d461cb89537b7c20feb04c46c32e12d5ad4f0896c9dfc0f60336219ff248e"},
-    {file = "llvmlite-0.46.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1f6595a35b7b39c3518b85a28bf18f45e075264e4b2dce3f0c2a4f232b4a910"},
-    {file = "llvmlite-0.46.0-cp310-cp310-win_amd64.whl", hash = "sha256:e7a34d4aa6f9a97ee006b504be6d2b8cb7f755b80ab2f344dda1ef992f828559"},
-    {file = "llvmlite-0.46.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82f3d39b16f19aa1a56d5fe625883a6ab600d5cc9ea8906cca70ce94cabba067"},
-    {file = "llvmlite-0.46.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3df43900119803bbc52720e758c76f316a9a0f34612a886862dfe0a5591a17e"},
-    {file = "llvmlite-0.46.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de183fefc8022d21b0aa37fc3e90410bc3524aed8617f0ff76732fc6c3af5361"},
-    {file = "llvmlite-0.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:e8b10bc585c58bdffec9e0c309bb7d51be1f2f15e169a4b4d42f2389e431eb93"},
-    {file = "llvmlite-0.46.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b9588ad4c63b4f0175a3984b85494f0c927c6b001e3a246a3a7fb3920d9a137"},
-    {file = "llvmlite-0.46.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3535bd2bb6a2d7ae4012681ac228e5132cdb75fefb1bcb24e33f2f3e0c865ed4"},
-    {file = "llvmlite-0.46.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cbfd366e60ff87ea6cc62f50bc4cd800ebb13ed4c149466f50cf2163a473d1e"},
-    {file = "llvmlite-0.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:398b39db462c39563a97b912d4f2866cd37cba60537975a09679b28fbbc0fb38"},
-    {file = "llvmlite-0.46.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:30b60892d034bc560e0ec6654737aaa74e5ca327bd8114d82136aa071d611172"},
-    {file = "llvmlite-0.46.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cc19b051753368a9c9f31dc041299059ee91aceec81bd57b0e385e5d5bf1a54"},
-    {file = "llvmlite-0.46.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bca185892908f9ede48c0acd547fe4dc1bafefb8a4967d47db6cf664f9332d12"},
-    {file = "llvmlite-0.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:67438fd30e12349ebb054d86a5a1a57fd5e87d264d2451bcfafbbbaa25b82a35"},
-    {file = "llvmlite-0.46.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:d252edfb9f4ac1fcf20652258e3f102b26b03eef738dc8a6ffdab7d7d341d547"},
-    {file = "llvmlite-0.46.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:379fdd1c59badeff8982cb47e4694a6143bec3bb49aa10a466e095410522064d"},
-    {file = "llvmlite-0.46.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e8cbfff7f6db0fa2c771ad24154e2a7e457c2444d7673e6de06b8b698c3b269"},
-    {file = "llvmlite-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:7821eda3ec1f18050f981819756631d60b6d7ab1a6cf806d9efefbe3f4082d61"},
-    {file = "llvmlite-0.46.0.tar.gz", hash = "sha256:227c9fd6d09dce2783c18b754b7cd9d9b3b3515210c46acc2d3c5badd9870ceb"},
+    {file = "llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063"},
+    {file = "llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea"},
+    {file = "llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8"},
+    {file = "llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327"},
+    {file = "llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077"},
+    {file = "llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7"},
+    {file = "llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40"},
+    {file = "llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e"},
+    {file = "llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca"},
+    {file = "llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453"},
+    {file = "llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc"},
 ]
 
 [[package]]
@@ -4963,56 +4902,62 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.19.1"
+version = "1.20.0"
 description = "Optional static typing for Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mypy-1.19.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5f05aa3d375b385734388e844bc01733bd33c644ab48e9684faa54e5389775ec"},
-    {file = "mypy-1.19.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:022ea7279374af1a5d78dfcab853fe6a536eebfda4b59deab53cd21f6cd9f00b"},
-    {file = "mypy-1.19.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee4c11e460685c3e0c64a4c5de82ae143622410950d6be863303a1c4ba0e36d6"},
-    {file = "mypy-1.19.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de759aafbae8763283b2ee5869c7255391fbc4de3ff171f8f030b5ec48381b74"},
-    {file = "mypy-1.19.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ab43590f9cd5108f41aacf9fca31841142c786827a74ab7cc8a2eacb634e09a1"},
-    {file = "mypy-1.19.1-cp310-cp310-win_amd64.whl", hash = "sha256:2899753e2f61e571b3971747e302d5f420c3fd09650e1951e99f823bc3089dac"},
-    {file = "mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288"},
-    {file = "mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab"},
-    {file = "mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6"},
-    {file = "mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331"},
-    {file = "mypy-1.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925"},
-    {file = "mypy-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042"},
-    {file = "mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1"},
-    {file = "mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e"},
-    {file = "mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2"},
-    {file = "mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8"},
-    {file = "mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a"},
-    {file = "mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13"},
-    {file = "mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250"},
-    {file = "mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b"},
-    {file = "mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e"},
-    {file = "mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef"},
-    {file = "mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75"},
-    {file = "mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd"},
-    {file = "mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1"},
-    {file = "mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718"},
-    {file = "mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b"},
-    {file = "mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045"},
-    {file = "mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957"},
-    {file = "mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f"},
-    {file = "mypy-1.19.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7bcfc336a03a1aaa26dfce9fff3e287a3ba99872a157561cbfcebe67c13308e3"},
-    {file = "mypy-1.19.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b7951a701c07ea584c4fe327834b92a30825514c868b1f69c30445093fdd9d5a"},
-    {file = "mypy-1.19.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b13cfdd6c87fc3efb69ea4ec18ef79c74c3f98b4e5498ca9b85ab3b2c2329a67"},
-    {file = "mypy-1.19.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f28f99c824ecebcdaa2e55d82953e38ff60ee5ec938476796636b86afa3956e"},
-    {file = "mypy-1.19.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c608937067d2fc5a4dd1a5ce92fd9e1398691b8c5d012d66e1ddd430e9244376"},
-    {file = "mypy-1.19.1-cp39-cp39-win_amd64.whl", hash = "sha256:409088884802d511ee52ca067707b90c883426bd95514e8cfda8281dc2effe24"},
-    {file = "mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247"},
-    {file = "mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba"},
+    {file = "mypy-1.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d99f515f95fd03a90875fdb2cca12ff074aa04490db4d190905851bdf8a549a8"},
+    {file = "mypy-1.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bd0212976dc57a5bfeede7c219e7cd66568a32c05c9129686dd487c059c1b88a"},
+    {file = "mypy-1.20.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f8426d4d75d68714abc17a4292d922f6ba2cfb984b72c2278c437f6dae797865"},
+    {file = "mypy-1.20.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02cca0761c75b42a20a2757ae58713276605eb29a08dd8a6e092aa347c4115ca"},
+    {file = "mypy-1.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b3a49064504be59e59da664c5e149edc1f26c67c4f8e8456f6ba6aba55033018"},
+    {file = "mypy-1.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:ebea00201737ad4391142808ed16e875add5c17f676e0912b387739f84991e13"},
+    {file = "mypy-1.20.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80cf77847d0d3e6e3111b7b25db32a7f8762fd4b9a3a72ce53fe16a2863b281"},
+    {file = "mypy-1.20.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4525e7010b1b38334516181c5b81e16180b8e149e6684cee5a727c78186b4e3b"},
+    {file = "mypy-1.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a17c5d0bdcca61ce24a35beb828a2d0d323d3fcf387d7512206888c900193367"},
+    {file = "mypy-1.20.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f75ff57defcd0f1d6e006d721ccdec6c88d4f6a7816eb92f1c4890d979d9ee62"},
+    {file = "mypy-1.20.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b503ab55a836136b619b5fc21c8803d810c5b87551af8600b72eecafb0059cb0"},
+    {file = "mypy-1.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1973868d2adbb4584a3835780b27436f06d1dc606af5be09f187aaa25be1070f"},
+    {file = "mypy-1.20.0-cp311-cp311-win_amd64.whl", hash = "sha256:2fcedb16d456106e545b2bfd7ef9d24e70b38ec252d2a629823a4d07ebcdb69e"},
+    {file = "mypy-1.20.0-cp311-cp311-win_arm64.whl", hash = "sha256:379edf079ce44ac8d2805bcf9b3dd7340d4f97aad3a5e0ebabbf9d125b84b442"},
+    {file = "mypy-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:002b613ae19f4ac7d18b7e168ffe1cb9013b37c57f7411984abbd3b817b0a214"},
+    {file = "mypy-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9336b5e6712f4adaf5afc3203a99a40b379049104349d747eb3e5a3aa23ac2e"},
+    {file = "mypy-1.20.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f13b3e41bce9d257eded794c0f12878af3129d80aacd8a3ee0dee51f3a978651"},
+    {file = "mypy-1.20.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9804c3ad27f78e54e58b32e7cb532d128b43dbfb9f3f9f06262b821a0f6bd3f5"},
+    {file = "mypy-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:697f102c5c1d526bdd761a69f17c6070f9892eebcb94b1a5963d679288c09e78"},
+    {file = "mypy-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ecd63f75fdd30327e4ad8b5704bd6d91fc6c1b2e029f8ee14705e1207212489"},
+    {file = "mypy-1.20.0-cp312-cp312-win_arm64.whl", hash = "sha256:f194db59657c58593a3c47c6dfd7bad4ef4ac12dbc94d01b3a95521f78177e33"},
+    {file = "mypy-1.20.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b20c8b0fd5877abdf402e79a3af987053de07e6fb208c18df6659f708b535134"},
+    {file = "mypy-1.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:367e5c993ba34d5054d11937d0485ad6dfc60ba760fa326c01090fc256adf15c"},
+    {file = "mypy-1.20.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f799d9db89fc00446f03281f84a221e50018fc40113a3ba9864b132895619ebe"},
+    {file = "mypy-1.20.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555658c611099455b2da507582ea20d2043dfdfe7f5ad0add472b1c6238b433f"},
+    {file = "mypy-1.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:efe8d70949c3023698c3fca1e94527e7e790a361ab8116f90d11221421cd8726"},
+    {file = "mypy-1.20.0-cp313-cp313-win_amd64.whl", hash = "sha256:f49590891d2c2f8a9de15614e32e459a794bcba84693c2394291a2038bbaaa69"},
+    {file = "mypy-1.20.0-cp313-cp313-win_arm64.whl", hash = "sha256:76a70bf840495729be47510856b978f1b0ec7d08f257ca38c9d932720bf6b43e"},
+    {file = "mypy-1.20.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f42dfaab7ec1baff3b383ad7af562ab0de573c5f6edb44b2dab016082b89948"},
+    {file = "mypy-1.20.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:31b5dbb55293c1bd27c0fc813a0d2bb5ceef9d65ac5afa2e58f829dab7921fd5"},
+    {file = "mypy-1.20.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d11c6f573a5a08f77fad13faff2139f6d0730ebed2cfa9b3d2702671dd7188"},
+    {file = "mypy-1.20.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d3243c406773185144527f83be0e0aefc7bf4601b0b2b956665608bf7c98a83"},
+    {file = "mypy-1.20.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a79c1eba7ac4209f2d850f0edd0a2f8bba88cbfdfefe6fb76a19e9d4fe5e71a2"},
+    {file = "mypy-1.20.0-cp314-cp314-win_amd64.whl", hash = "sha256:00e047c74d3ec6e71a2eb88e9ea551a2edb90c21f993aefa9e0d2a898e0bb732"},
+    {file = "mypy-1.20.0-cp314-cp314-win_arm64.whl", hash = "sha256:931a7630bba591593dcf6e97224a21ff80fb357e7982628d25e3c618e7f598ef"},
+    {file = "mypy-1.20.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:26c8b52627b6552f47ff11adb4e1509605f094e29815323e487fc0053ebe93d1"},
+    {file = "mypy-1.20.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:39362cdb4ba5f916e7976fccecaab1ba3a83e35f60fa68b64e9a70e221bb2436"},
+    {file = "mypy-1.20.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34506397dbf40c15dc567635d18a21d33827e9ab29014fb83d292a8f4f8953b6"},
+    {file = "mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526"},
+    {file = "mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787"},
+    {file = "mypy-1.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:47781555a7aa5fedcc2d16bcd72e0dc83eb272c10dd657f9fb3f9cc08e2e6abb"},
+    {file = "mypy-1.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:c70380fe5d64010f79fb863b9081c7004dd65225d2277333c219d93a10dad4dd"},
+    {file = "mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e"},
+    {file = "mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3"},
 ]
 
 [package.dependencies]
-librt = {version = ">=0.6.2", markers = "platform_python_implementation != \"PyPy\""}
+librt = {version = ">=0.8.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
-pathspec = ">=0.9.0"
+pathspec = ">=1.0.0"
 typing_extensions = ">=4.6.0"
 
 [package.extras]
@@ -5020,6 +4965,7 @@ dmypy = ["psutil (>=4.0)"]
 faster-cache = ["orjson"]
 install-types = ["pip"]
 mypyc = ["setuptools (>=50)"]
+native-parser = ["ast-serialize (>=0.1.1,<1.0.0)"]
 reports = ["lxml"]
 
 [[package]]
@@ -5086,14 +5032,14 @@ test = ["flaky", "ipykernel (>=6.19.3)", "ipython", "ipywidgets", "nbconvert (>=
 
 [[package]]
 name = "nbconvert"
-version = "7.17.0"
+version = "7.17.1"
 description = "Convert Jupyter Notebooks (.ipynb files) to other formats."
 optional = false
 python-versions = ">=3.9"
 groups = ["custom"]
 files = [
-    {file = "nbconvert-7.17.0-py3-none-any.whl", hash = "sha256:4f99a63b337b9a23504347afdab24a11faa7d86b405e5c8f9881cd313336d518"},
-    {file = "nbconvert-7.17.0.tar.gz", hash = "sha256:1b2696f1b5be12309f6c7d707c24af604b87dfaf6d950794c7b07acab96dda78"},
+    {file = "nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8"},
+    {file = "nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2"},
 ]
 
 [package.dependencies]
@@ -5295,37 +5241,41 @@ test = ["pytest", "pytest-console-scripts", "pytest-jupyter", "pytest-tornasync"
 
 [[package]]
 name = "numba"
-version = "0.64.0"
+version = "0.65.0"
 description = "compiling Python code using LLVM"
 optional = false
 python-versions = ">=3.10"
 groups = ["custom"]
 files = [
-    {file = "numba-0.64.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cc09b79440952e3098eeebea4bf6e8d2355fb7f12734fcd9fc5039f0dca90727"},
-    {file = "numba-0.64.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1afe3a80b8c2f376b211fb7a49e536ef9eafc92436afc95a2f41ea5392f8cc65"},
-    {file = "numba-0.64.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23804194b93b8cd416c6444b5fbc4956082a45fed2d25436ef49c594666e7f7e"},
-    {file = "numba-0.64.0-cp310-cp310-win_amd64.whl", hash = "sha256:e2a9fe998bb2cf848960b34db02c2c3b5e02cf82c07a26d9eef3494069740278"},
-    {file = "numba-0.64.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:766156ee4b8afeeb2b2e23c81307c5d19031f18d5ce76ae2c5fb1429e72fa92b"},
-    {file = "numba-0.64.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d17071b4ffc9d39b75d8e6c101a36f0c81b646123859898c9799cb31807c8f78"},
-    {file = "numba-0.64.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ead5630434133bac87fa67526eacb264535e4e9a2d5ec780e0b4fc381a7d275"},
-    {file = "numba-0.64.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2b1fd93e7aaac07d6fbaed059c00679f591f2423885c206d8c1b55d65ca3f2d"},
-    {file = "numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69440a8e8bc1a81028446f06b363e28635aa67bd51b1e498023f03b812e0ce68"},
-    {file = "numba-0.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f13721011f693ba558b8dd4e4db7f2640462bba1b855bdc804be45bbeb55031a"},
-    {file = "numba-0.64.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0b180b1133f2b5d8b3f09d96b6d7a9e51a7da5dda3c09e998b5bcfac85d222c"},
-    {file = "numba-0.64.0-cp312-cp312-win_amd64.whl", hash = "sha256:e63dc94023b47894849b8b106db28ccb98b49d5498b98878fac1a38f83ac007a"},
-    {file = "numba-0.64.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3bab2c872194dcd985f1153b70782ec0fbbe348fffef340264eacd3a76d59fd6"},
-    {file = "numba-0.64.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:703a246c60832cad231d2e73c1182f25bf3cc8b699759ec8fe58a2dbc689a70c"},
-    {file = "numba-0.64.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2e49a7900ee971d32af7609adc0cfe6aa7477c6f6cccdf6d8138538cf7756f"},
-    {file = "numba-0.64.0-cp313-cp313-win_amd64.whl", hash = "sha256:396f43c3f77e78d7ec84cdfc6b04969c78f8f169351b3c4db814b97e7acf4245"},
-    {file = "numba-0.64.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f565d55eaeff382cbc86c63c8c610347453af3d1e7afb2b6569aac1c9b5c93ce"},
-    {file = "numba-0.64.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b55169b18892c783f85e9ad9e6f5297a6d12967e4414e6b71361086025ff0bb"},
-    {file = "numba-0.64.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:196bcafa02c9dd1707e068434f6d5cedde0feb787e3432f7f1f0e993cc336c4c"},
-    {file = "numba-0.64.0-cp314-cp314-win_amd64.whl", hash = "sha256:213e9acbe7f1c05090592e79020315c1749dd52517b90e94c517dca3f014d4a1"},
-    {file = "numba-0.64.0.tar.gz", hash = "sha256:95e7300af648baa3308127b1955b52ce6d11889d16e8cfe637b4f85d2fca52b1"},
+    {file = "numba-0.65.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:dff9fd5fbc9a35c517359c5823ea705d9b65f01fb46e42e35a2eabe5a52c2e96"},
+    {file = "numba-0.65.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4c894c94afa5ffd627c7e3b693df10cb0d905bd5eb06de3dfc31775140cf4f89"},
+    {file = "numba-0.65.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7325b1aab88f0339057288ee32f39dc660e14f93872a6fda14fa6eb9f95b047"},
+    {file = "numba-0.65.0-cp310-cp310-win_amd64.whl", hash = "sha256:71e72e9ca2f619df4768f9c3962bfec60191a5a26fe2b6a8c6a07532b6146169"},
+    {file = "numba-0.65.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:28e547d0b18024f19cbaf9de02fc5c145790213d9be8a2c95b43f93ec162b9e4"},
+    {file = "numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:032b0b8e879512cd424d79eed6d772a1399c6387ded184c2cf3cc22c08d750a6"},
+    {file = "numba-0.65.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af143d823624033a128b5950c0aaf9ffc2386dfe954eb757119cf0432335534c"},
+    {file = "numba-0.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:15d159578e59a39df246b83480f78d7794b0fca40153b5684d3849a99c48a0fb"},
+    {file = "numba-0.65.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b27ee4847e1bfb17e9604d100417ee7c1d10f15a6711c6213404b3da13a0b2aa"},
+    {file = "numba-0.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a52d92ffd297c10364bce60cd1fcb88f99284ab5df085f2c6bcd1cb33b529a6f"},
+    {file = "numba-0.65.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da8e371e328c06d0010c3d8b44b21858652831b85bcfba78cb22c042e22dbd8e"},
+    {file = "numba-0.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:59bb9f2bb9f1238dfd8e927ba50645c18ae769fef4f3d58ea0ea22a2683b91f5"},
+    {file = "numba-0.65.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c6334094563a456a695c812e6846288376ca02327cf246cdcc83e1bb27862367"},
+    {file = "numba-0.65.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b8a9008411615c69d083d1dcf477f75a5aa727b30beb16e139799e2be945cdfd"},
+    {file = "numba-0.65.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af96c0cba53664efcb361528b8c75e011a6556c859c7e08424c2715201c6cf7a"},
+    {file = "numba-0.65.0-cp313-cp313-win_amd64.whl", hash = "sha256:6254e73b9c929dc736a1fbd3d6f5680789709a5067cae1fa7198707385129c04"},
+    {file = "numba-0.65.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ee336b398a6fca51b1f626034de99f50cb1bd87d537a166275158a3cee744b82"},
+    {file = "numba-0.65.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05c0a9fdf75d85f57dee47b719e8d6415707b80aae45d75f63f9dc1b935c29f7"},
+    {file = "numba-0.65.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:583680e0e8faf124d362df23b4b593f3221a8996341a63d1b664c122401bec2f"},
+    {file = "numba-0.65.0-cp314-cp314-win_amd64.whl", hash = "sha256:add297d3e1c08dd884f44100152612fa41e66a51d15fdf91307f9dde31d06830"},
+    {file = "numba-0.65.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:194a243ba53a9157c8538cbb3166ec015d785a8c5d584d06cdd88bee902233c7"},
+    {file = "numba-0.65.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fa502960f7a2f3f5cb025bc7bff888a3551277b92431bfdc5ba2f11a375749"},
+    {file = "numba-0.65.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5046c63f783ca3eb6195f826a50797465e7c4ce811daa17c9bea47e310c9b964"},
+    {file = "numba-0.65.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46fd679ae4f68c7a5d5721efbd29ecee0b0f3013211591891d79b51bfdf73113"},
+    {file = "numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b"},
 ]
 
 [package.dependencies]
-llvmlite = "==0.46.*"
+llvmlite = "==0.47.*"
 numpy = ">=1.22,<2.5"
 
 [[package]]
@@ -5649,7 +5599,7 @@ zarr = "2.18.4"
 type = "git"
 url = "https://github.com/aitmohandk/oceanbench.git"
 reference = "main"
-resolved_reference = "1a4b256135554bd494abb796b23b1f6099972ea9"
+resolved_reference = "fb1e63e1d916666ab2499f01b9a5da37f00af33d"
 
 [[package]]
 name = "omegaconf"
@@ -5975,103 +5925,103 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "12.2.0"
 description = "Python Imaging Library (fork)"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "pillow-12.1.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1f1625b72740fdda5d77b4def688eb8fd6490975d06b909fd19f13f391e077e0"},
-    {file = "pillow-12.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:178aa072084bd88ec759052feca8e56cbb14a60b39322b99a049e58090479713"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b66e95d05ba806247aaa1561f080abc7975daf715c30780ff92a20e4ec546e1b"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89c7e895002bbe49cdc5426150377cbbc04767d7547ed145473f496dfa40408b"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a5cbdcddad0af3da87cb16b60d23648bc3b51967eb07223e9fed77a82b457c4"},
-    {file = "pillow-12.1.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f51079765661884a486727f0729d29054242f74b46186026582b4e4769918e4"},
-    {file = "pillow-12.1.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:99c1506ea77c11531d75e3a412832a13a71c7ebc8192ab9e4b2e355555920e3e"},
-    {file = "pillow-12.1.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36341d06738a9f66c8287cf8b876d24b18db9bd8740fa0672c74e259ad408cff"},
-    {file = "pillow-12.1.1-cp310-cp310-win32.whl", hash = "sha256:6c52f062424c523d6c4db85518774cc3d50f5539dd6eed32b8f6229b26f24d40"},
-    {file = "pillow-12.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:c6008de247150668a705a6338156efb92334113421ceecf7438a12c9a12dab23"},
-    {file = "pillow-12.1.1-cp310-cp310-win_arm64.whl", hash = "sha256:1a9b0ee305220b392e1124a764ee4265bd063e54a751a6b62eff69992f457fa9"},
-    {file = "pillow-12.1.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e879bb6cd5c73848ef3b2b48b8af9ff08c5b71ecda8048b7dd22d8a33f60be32"},
-    {file = "pillow-12.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:365b10bb9417dd4498c0e3b128018c4a624dc11c7b97d8cc54effe3b096f4c38"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d4ce8e329c93845720cd2014659ca67eac35f6433fd3050393d85f3ecef0dad5"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc354a04072b765eccf2204f588a7a532c9511e8b9c7f900e1b64e3e33487090"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e7976bf1910a8116b523b9f9f58bf410f3e8aa330cd9a2bb2953f9266ab49af"},
-    {file = "pillow-12.1.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:597bd9c8419bc7c6af5604e55847789b69123bbe25d65cc6ad3012b4f3c98d8b"},
-    {file = "pillow-12.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c1fc0f2ca5f96a3c8407e41cca26a16e46b21060fe6d5b099d2cb01412222f5"},
-    {file = "pillow-12.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:578510d88c6229d735855e1f278aa305270438d36a05031dfaae5067cc8eb04d"},
-    {file = "pillow-12.1.1-cp311-cp311-win32.whl", hash = "sha256:7311c0a0dcadb89b36b7025dfd8326ecfa36964e29913074d47382706e516a7c"},
-    {file = "pillow-12.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:fbfa2a7c10cc2623f412753cddf391c7f971c52ca40a3f65dc5039b2939e8563"},
-    {file = "pillow-12.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:b81b5e3511211631b3f672a595e3221252c90af017e399056d0faabb9538aa80"},
-    {file = "pillow-12.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052"},
-    {file = "pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397"},
-    {file = "pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0"},
-    {file = "pillow-12.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3"},
-    {file = "pillow-12.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35"},
-    {file = "pillow-12.1.1-cp312-cp312-win32.whl", hash = "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a"},
-    {file = "pillow-12.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6"},
-    {file = "pillow-12.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9"},
-    {file = "pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6"},
-    {file = "pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60"},
-    {file = "pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e"},
-    {file = "pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717"},
-    {file = "pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a"},
-    {file = "pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029"},
-    {file = "pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b"},
-    {file = "pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1"},
-    {file = "pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a"},
-    {file = "pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da"},
-    {file = "pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20"},
-    {file = "pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13"},
-    {file = "pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf"},
-    {file = "pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524"},
-    {file = "pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986"},
-    {file = "pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c"},
-    {file = "pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f"},
-    {file = "pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642"},
-    {file = "pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd"},
-    {file = "pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f"},
-    {file = "pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e"},
-    {file = "pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0"},
-    {file = "pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb"},
-    {file = "pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f"},
-    {file = "pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15"},
-    {file = "pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f"},
-    {file = "pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8"},
-    {file = "pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f"},
-    {file = "pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586"},
-    {file = "pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce"},
-    {file = "pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8"},
-    {file = "pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36"},
-    {file = "pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b"},
-    {file = "pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:600fd103672b925fe62ed08e0d874ea34d692474df6f4bf7ebe148b30f89f39f"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:665e1b916b043cef294bc54d47bf02d87e13f769bc4bc5fa225a24b3a6c5aca9"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:495c302af3aad1ca67420ddd5c7bd480c8867ad173528767d906428057a11f0e"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8fd420ef0c52c88b5a035a0886f367748c72147b2b8f384c9d12656678dfdfa9"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735"},
-    {file = "pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e"},
-    {file = "pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4"},
+    {file = "pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f"},
+    {file = "pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136"},
+    {file = "pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c"},
+    {file = "pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3"},
+    {file = "pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa"},
+    {file = "pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032"},
+    {file = "pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5"},
+    {file = "pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024"},
+    {file = "pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab"},
+    {file = "pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705"},
+    {file = "pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176"},
+    {file = "pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b"},
+    {file = "pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909"},
+    {file = "pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808"},
+    {file = "pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60"},
+    {file = "pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe"},
+    {file = "pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5"},
+    {file = "pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005"},
+    {file = "pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780"},
+    {file = "pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5"},
+    {file = "pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5"},
+    {file = "pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940"},
+    {file = "pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5"},
+    {file = "pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2"},
+    {file = "pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c"},
+    {file = "pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795"},
+    {file = "pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed"},
+    {file = "pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3"},
+    {file = "pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9"},
+    {file = "pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795"},
+    {file = "pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e"},
+    {file = "pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b"},
+    {file = "pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06"},
+    {file = "pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b"},
+    {file = "pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea"},
+    {file = "pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4"},
+    {file = "pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4"},
+    {file = "pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea"},
+    {file = "pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24"},
+    {file = "pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98"},
+    {file = "pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b"},
+    {file = "pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295"},
+    {file = "pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed"},
+    {file = "pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f"},
+    {file = "pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286"},
+    {file = "pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50"},
+    {file = "pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104"},
+    {file = "pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7"},
+    {file = "pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150"},
+    {file = "pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1"},
+    {file = "pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463"},
+    {file = "pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd"},
+    {file = "pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e"},
+    {file = "pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06"},
+    {file = "pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43"},
+    {file = "pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354"},
+    {file = "pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1"},
+    {file = "pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1"},
+    {file = "pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e"},
+    {file = "pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5"},
 ]
 
 [package.extras]
@@ -6084,14 +6034,14 @@ xmp = ["defusedxml"]
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"},
-    {file = "platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934"},
+    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
+    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
 ]
 
 [[package]]
@@ -6131,14 +6081,14 @@ poetry-plugin = ["poetry (>=1.2.0,<3.0.0) ; python_version < \"4.0\""]
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.0"
 description = "Python client for the Prometheus monitoring system."
 optional = false
 python-versions = ">=3.9"
 groups = ["custom"]
 files = [
-    {file = "prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055"},
-    {file = "prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9"},
+    {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
+    {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
 ]
 
 [package.extras]
@@ -6311,18 +6261,18 @@ scipy = "*"
 
 [[package]]
 name = "proto-plus"
-version = "1.27.1"
+version = "1.27.2"
 description = "Beautiful, Pythonic protocol buffers"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc"},
-    {file = "proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147"},
+    {file = "proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718"},
+    {file = "proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24"},
 ]
 
 [package.dependencies]
-protobuf = ">=3.19.0,<7.0.0"
+protobuf = ">=4.25.8,<8.0.0"
 
 [package.extras]
 testing = ["google-api-core (>=1.31.5)"]
@@ -6412,58 +6362,63 @@ tests = ["pytest"]
 
 [[package]]
 name = "pyarrow"
-version = "18.1.0"
+version = "23.0.1"
 description = "Python library for Apache Arrow"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "pyarrow-18.1.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e21488d5cfd3d8b500b3238a6c4b075efabc18f0f6d80b29239737ebd69caa6c"},
-    {file = "pyarrow-18.1.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:b516dad76f258a702f7ca0250885fc93d1fa5ac13ad51258e39d402bd9e2e1e4"},
-    {file = "pyarrow-18.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f443122c8e31f4c9199cb23dca29ab9427cef990f283f80fe15b8e124bcc49b"},
-    {file = "pyarrow-18.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a03da7f2758645d17b7b4f83c8bffeae5bbb7f974523fe901f36288d2eab71"},
-    {file = "pyarrow-18.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ba17845efe3aa358ec266cf9cc2800fa73038211fb27968bfa88acd09261a470"},
-    {file = "pyarrow-18.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:3c35813c11a059056a22a3bef520461310f2f7eea5c8a11ef9de7062a23f8d56"},
-    {file = "pyarrow-18.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9736ba3c85129d72aefa21b4f3bd715bc4190fe4426715abfff90481e7d00812"},
-    {file = "pyarrow-18.1.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:eaeabf638408de2772ce3d7793b2668d4bb93807deed1725413b70e3156a7854"},
-    {file = "pyarrow-18.1.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:3b2e2239339c538f3464308fd345113f886ad031ef8266c6f004d49769bb074c"},
-    {file = "pyarrow-18.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f39a2e0ed32a0970e4e46c262753417a60c43a3246972cfc2d3eb85aedd01b21"},
-    {file = "pyarrow-18.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e31e9417ba9c42627574bdbfeada7217ad8a4cbbe45b9d6bdd4b62abbca4c6f6"},
-    {file = "pyarrow-18.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:01c034b576ce0eef554f7c3d8c341714954be9b3f5d5bc7117006b85fcf302fe"},
-    {file = "pyarrow-18.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f266a2c0fc31995a06ebd30bcfdb7f615d7278035ec5b1cd71c48d56daaf30b0"},
-    {file = "pyarrow-18.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:d4f13eee18433f99adefaeb7e01d83b59f73360c231d4782d9ddfaf1c3fbde0a"},
-    {file = "pyarrow-18.1.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:9f3a76670b263dc41d0ae877f09124ab96ce10e4e48f3e3e4257273cee61ad0d"},
-    {file = "pyarrow-18.1.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:da31fbca07c435be88a0c321402c4e31a2ba61593ec7473630769de8346b54ee"},
-    {file = "pyarrow-18.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:543ad8459bc438efc46d29a759e1079436290bd583141384c6f7a1068ed6f992"},
-    {file = "pyarrow-18.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0743e503c55be0fdb5c08e7d44853da27f19dc854531c0570f9f394ec9671d54"},
-    {file = "pyarrow-18.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d4b3d2a34780645bed6414e22dda55a92e0fcd1b8a637fba86800ad737057e33"},
-    {file = "pyarrow-18.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c52f81aa6f6575058d8e2c782bf79d4f9fdc89887f16825ec3a66607a5dd8e30"},
-    {file = "pyarrow-18.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ad4892617e1a6c7a551cfc827e072a633eaff758fa09f21c4ee548c30bcaf99"},
-    {file = "pyarrow-18.1.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:84e314d22231357d473eabec709d0ba285fa706a72377f9cc8e1cb3c8013813b"},
-    {file = "pyarrow-18.1.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:f591704ac05dfd0477bb8f8e0bd4b5dc52c1cadf50503858dce3a15db6e46ff2"},
-    {file = "pyarrow-18.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acb7564204d3c40babf93a05624fc6a8ec1ab1def295c363afc40b0c9e66c191"},
-    {file = "pyarrow-18.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74de649d1d2ccb778f7c3afff6085bd5092aed4c23df9feeb45dd6b16f3811aa"},
-    {file = "pyarrow-18.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f96bd502cb11abb08efea6dab09c003305161cb6c9eafd432e35e76e7fa9b90c"},
-    {file = "pyarrow-18.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ac22d7782554754a3b50201b607d553a8d71b78cdf03b33c1125be4b52397c"},
-    {file = "pyarrow-18.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:25dbacab8c5952df0ca6ca0af28f50d45bd31c1ff6fcf79e2d120b4a65ee7181"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a276190309aba7bc9d5bd2933230458b3521a4317acfefe69a354f2fe59f2bc"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:ad514dbfcffe30124ce655d72771ae070f30bf850b48bc4d9d3b25993ee0e386"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aebc13a11ed3032d8dd6e7171eb6e86d40d67a5639d96c35142bd568b9299324"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6cf5c05f3cee251d80e98726b5c7cc9f21bab9e9783673bac58e6dfab57ecc8"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:11b676cd410cf162d3f6a70b43fb9e1e40affbc542a1e9ed3681895f2962d3d9"},
-    {file = "pyarrow-18.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:b76130d835261b38f14fc41fdfb39ad8d672afb84c447126b84d5472244cfaba"},
-    {file = "pyarrow-18.1.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:0b331e477e40f07238adc7ba7469c36b908f07c89b95dd4bd3a0ec84a3d1e21e"},
-    {file = "pyarrow-18.1.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:2c4dd0c9010a25ba03e198fe743b1cc03cd33c08190afff371749c52ccbbaf76"},
-    {file = "pyarrow-18.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f97b31b4c4e21ff58c6f330235ff893cc81e23da081b1a4b1c982075e0ed4e9"},
-    {file = "pyarrow-18.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a4813cb8ecf1809871fd2d64a8eff740a1bd3691bbe55f01a3cf6c5ec869754"},
-    {file = "pyarrow-18.1.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:05a5636ec3eb5cc2a36c6edb534a38ef57b2ab127292a716d00eabb887835f1e"},
-    {file = "pyarrow-18.1.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:73eeed32e724ea3568bb06161cad5fa7751e45bc2228e33dcb10c614044165c7"},
-    {file = "pyarrow-18.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:a1880dd6772b685e803011a6b43a230c23b566859a6e0c9a276c1e0faf4f4052"},
-    {file = "pyarrow-18.1.0.tar.gz", hash = "sha256:9386d3ca9c145b5539a1cfc75df07757dff870168c959b473a0bccbc3abc8c73"},
+    {file = "pyarrow-23.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3fab8f82571844eb3c460f90a75583801d14ca0cc32b1acc8c361650e006fd56"},
+    {file = "pyarrow-23.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3f91c038b95f71ddfc865f11d5876c42f343b4495535bd262c7b321b0b94507c"},
+    {file = "pyarrow-23.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d0744403adabef53c985a7f8a082b502a368510c40d184df349a0a8754533258"},
+    {file = "pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c33b5bf406284fd0bba436ed6f6c3ebe8e311722b441d89397c54f871c6863a2"},
+    {file = "pyarrow-23.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ddf743e82f69dcd6dbbcb63628895d7161e04e56794ef80550ac6f3315eeb1d5"},
+    {file = "pyarrow-23.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e052a211c5ac9848ae15d5ec875ed0943c0221e2fcfe69eee80b604b4e703222"},
+    {file = "pyarrow-23.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:5abde149bb3ce524782d838eb67ac095cd3fd6090eba051130589793f1a7f76d"},
+    {file = "pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb"},
+    {file = "pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350"},
+    {file = "pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd"},
+    {file = "pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9"},
+    {file = "pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701"},
+    {file = "pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78"},
+    {file = "pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919"},
+    {file = "pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f"},
+    {file = "pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7"},
+    {file = "pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9"},
+    {file = "pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05"},
+    {file = "pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67"},
+    {file = "pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730"},
+    {file = "pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0"},
+    {file = "pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8"},
+    {file = "pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f"},
+    {file = "pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677"},
+    {file = "pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2"},
+    {file = "pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37"},
+    {file = "pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2"},
+    {file = "pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125"},
+    {file = "pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8"},
+    {file = "pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca"},
+    {file = "pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1"},
+    {file = "pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb"},
+    {file = "pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1"},
+    {file = "pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886"},
+    {file = "pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f"},
+    {file = "pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690"},
+    {file = "pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce"},
+    {file = "pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019"},
 ]
-
-[package.extras]
-test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
 [[package]]
 name = "pyarrow-hotfix"
@@ -6648,14 +6603,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "custom", "docs"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -7036,29 +6991,29 @@ six = ">=1.5"
 
 [[package]]
 name = "python-json-logger"
-version = "4.0.0"
+version = "4.1.0"
 description = "JSON Log Formatter for the Python Logging Package"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main", "custom"]
 files = [
-    {file = "python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2"},
-    {file = "python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f"},
+    {file = "python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2"},
+    {file = "python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195"},
 ]
 
 [package.extras]
-dev = ["backports.zoneinfo ; python_version < \"3.9\"", "black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec ; implementation_name != \"pypy\"", "mypy", "orjson ; implementation_name != \"pypy\"", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
+dev = ["black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec ; implementation_name != \"pypy\"", "mypy", "orjson ; implementation_name != \"pypy\"", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
 
 [[package]]
 name = "pytools"
-version = "2025.2.5"
+version = "2026.1"
 description = "A collection of tools for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["custom"]
 files = [
-    {file = "pytools-2025.2.5-py3-none-any.whl", hash = "sha256:42e93751ec425781e103bbcd769ba35ecbacd43339c2905401608f2fdc30cf19"},
-    {file = "pytools-2025.2.5.tar.gz", hash = "sha256:a7f5350644d46d98ee9c7e67b4b41693308aa0f5e9b188d8f0694b27dc94e3a2"},
+    {file = "pytools-2026.1-py3-none-any.whl", hash = "sha256:e4936d23fe553a62dfe449eba6ad61c620d6910a9487f8b0147f9e1a1abeb994"},
+    {file = "pytools-2026.1.tar.gz", hash = "sha256:7b6438ca5ecdedee42e16c8cb702c2ae562a98fb262dac1a3b01b121cc34bed5"},
 ]
 
 [package.dependencies]
@@ -7417,25 +7372,25 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "custom", "docs"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"},
+    {file = "requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "rfc3339-validator"
@@ -7484,14 +7439,14 @@ testing = ["pytest (>=8.3.5)"]
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 groups = ["main"]
 files = [
-    {file = "rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d"},
-    {file = "rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"},
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
 ]
 
 [package.dependencies]
@@ -7683,20 +7638,20 @@ files = [
 
 [[package]]
 name = "s3fs"
-version = "2026.2.0"
+version = "2026.3.0"
 description = "Convenient Filesystem interface over S3"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "s3fs-2026.2.0-py3-none-any.whl", hash = "sha256:65198835b86b1d5771112b0085d1da52a6ede36508b1aaa6cae2aedc765dfe10"},
-    {file = "s3fs-2026.2.0.tar.gz", hash = "sha256:91cb2a9f76e35643b76eeac3f47a6165172bb3def671f76b9111c8dd5779a2ac"},
+    {file = "s3fs-2026.3.0-py3-none-any.whl", hash = "sha256:2fa40a64c03003cfa5ae0e352788d97aa78ae8f9e25ea98b28ce9d21ba10c1b8"},
+    {file = "s3fs-2026.3.0.tar.gz", hash = "sha256:ce8b30a9dc5e01c5127c96cb7377290243a689a251ef9257336ac29d72d7b0d8"},
 ]
 
 [package.dependencies]
 aiobotocore = ">=2.19.0,<4.0.0"
-aiohttp = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
-fsspec = "2026.2.0"
+aiohttp = ">=3.9.0,<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
+fsspec = "2026.3.0"
 
 [[package]]
 name = "s3transfer"
@@ -8888,14 +8843,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main", "custom"]
 files = [
-    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
-    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+    {file = "tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"},
+    {file = "tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ pygments = "^2.19.1"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"
-requires = ["poetry-core", "setuptools", "wheel", "cmake"]
+requires = ["poetry-core", "setuptools", "wheel"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Improve memory management, evaluation robustness, and per-bin metrics support

- Evaluator: add glibc malloc arena/mmap tuning for Dask workers to reduce
  unmanaged memory; add memory logging helpers; handle cluster shutdown
  before performance_report exit; add per-bin depth metrics support
- OceanBench metrics: add per-depth-bin evaluation output
- Processing base: add per-bins JSONL aggregation, batch prefetch iterator,
  and compact JSON helpers; refactor post-processing pipeline
- Dataloader: add parallel worker count parameter; build missing time
  sidecar (time_index.npy) for reused shared batch zarr
- Dask init: suppress distributed.* log noise with persistent filter;
  monkey-patch dictConfig to survive logger resets
- Runner: add styled terminal banners for eval results; handle
  ValueError when Dask client is closed before performance_report exit
- Remove cmake from build-system requires
- Misc: lazy local_root directory creation, remove premature data_root mkdir