### PR TITLE
fix: robustness improvements across catalog, loader, evaluator and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,33 @@ poetry install --with docs
 Here's a simple example to get started:
 
 ```python
-from dctools.data import EvaluationDataloader
-from dctools.metrics import Evaluator
 import xarray as xr
 
-# Load data from multiple sources
-dataloader = EvaluationDataloader()
-ds = dataloader.load_dataset(source="argo")  # or "cmems", "s3", "local"
+from dctools.data.coordinates import CoordinateSystem
+from dctools.dcio.saver import DataSaver
+from dctools.metrics.metrics import MetricComputer
 
-# Evaluate against reference data
-evaluator = Evaluator()
-metrics = evaluator.evaluate(ds, reference_ds)
+# Load prediction/reference datasets
+pred_ds = xr.open_dataset("prediction.nc")
+ref_ds = xr.open_dataset("reference.nc")
 
-print(f"RMSE: {metrics['rmse']}")
-print(f"MAE: {metrics['mae']}")
+# Inspect and normalize coordinate conventions
+pred_coords = CoordinateSystem(pred_ds)
+ref_coords = CoordinateSystem(ref_ds)
+
+# Compute metrics
+metric_computer = MetricComputer(eval_variables=["so", "thetao"])
+metrics = metric_computer.compute(
+    pred_data=pred_ds,
+    ref_data=ref_ds,
+    pred_coords=pred_coords,
+    ref_coords=ref_coords,
+)
+
+print(metrics)
+
+# Save processed output if needed
+DataSaver.save_dataset(pred_ds, "prediction_copy.nc", file_format="netcdf")
 ```
 
 ### Running from configuration
@@ -111,7 +124,7 @@ evaluation:
 Then run via CLI:
 
 ```bash
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
 ## 📁 Project Structure
@@ -153,14 +166,13 @@ dc-tools/
 ### Loading Data
 
 ```python
-from dctools.data import EvaluationDataloader, CoordinateSystem
+import xarray as xr
 
-# Initialize data loader
-loader = EvaluationDataloader()
+from dctools.data.coordinates import CoordinateSystem
 
-# Load from different sources
-argo_data = loader.load_dataset(source="argo", region="north_atlantic")
-cmems_data = loader.load_dataset(source="cmems", variables=["SO", "THETAO"])
+# Load from local files (or use your own data access layer)
+argo_data = xr.open_dataset("argo_profiles.nc")
+cmems_data = xr.open_dataset("cmems_forecast.nc")
 
 # Automatic coordinate detection and normalization
 cs = CoordinateSystem(argo_data)
@@ -170,60 +182,59 @@ normalized = cs.get_target_dimensions()
 ### Processing Data
 
 ```python
-from dctools.processing import interpolate_dataset
+from dctools.processing.interpolation import interpolate_dataset
 
 # Interpolate to a standard grid
-target_grid = xr.open_dataset("target_grid.nc")
+target_grid = {
+  "lat": argo_data["lat"].values,
+  "lon": argo_data["lon"].values,
+}
 interpolated = interpolate_dataset(
     cmems_data,
-    target_grid,
-    method="bilinear"
+  target_grid=target_grid,
+  interpolation_lib="pyinterp",
 )
 ```
 
 ### Computing Metrics
 
 ```python
-from dctools.metrics import MetricComputer
+from dctools.metrics.metrics import MetricComputer
 
 # Compute evaluation metrics
-metric_computer = MetricComputer(variables=["SO", "THETAO"])
+metric_computer = MetricComputer(eval_variables=["so", "thetao"])
 results = metric_computer.compute(
-    prediction=interpolated,
-    reference=argo_data,
-    metrics=["rmse", "mae", "bias"]
+  pred_data=interpolated,
+  ref_data=argo_data,
 )
 ```
 
 ### Distributed Evaluation with Dask
 
 ```python
-from dctools.metrics import Evaluator
 from dask.distributed import Client
 
-# Setup Dask cluster
+from dc2.evaluation.evaluation import DC2Evaluation
+from dctools.utilities.args_config import load_args_and_config
+
 with Client(n_workers=4, threads_per_worker=2):
-    evaluator = Evaluator()
-    
-    # Evaluation automatically uses Dask parallelism
-    results = evaluator.evaluate(
-        datasets=[ds1, ds2, ds3],
-        reference=reference_ds
-    )
+  args = load_args_and_config("dc2/config/dc2.yaml")
+  evaluator = DC2Evaluation(args)
+  evaluator.run_eval()
 ```
 
 ### Saving Results
 
 ```python
-from dctools.dcio import DataSaver
+from dctools.dcio.saver import DataSaver
 
 saver = DataSaver()
 
 # Save to NetCDF
-saver.save_dataset(results, "results.nc", format="netcdf")
+saver.save_dataset(results, "results.nc", file_format="netcdf")
 
 # Save to Zarr (preferred for large datasets)
-saver.save_dataset(results, "results.zarr", format="zarr")
+saver.save_dataset(results, "results.zarr", file_format="zarr")
 ```
 
 ## 🧪 Testing

--- a/dctools/data/connection/connection_manager.py
+++ b/dctools/data/connection/connection_manager.py
@@ -261,6 +261,26 @@ def get_time_bound_values(ds: xr.Dataset) -> tuple:
                 if np.isnan(num_min) or np.isnan(num_max):
                     return (None, None)
                 return (num_min, num_max)
+            elif time_vals.dtype == object:
+                # cftime objects (from use_cftime=True) or other object arrays
+                try:
+                    values = np.asarray(time_vals.values).ravel()
+                    if len(values) == 0:
+                        return (None, None)
+                    t_min = values.min()
+                    t_max = values.max()
+                    return (pd.Timestamp(t_min.isoformat()), pd.Timestamp(t_max.isoformat()))
+                except Exception:
+                    try:
+                        converted = pd.to_datetime(
+                            [str(v) for v in values], errors="coerce"
+                        )
+                        valid = converted.dropna()
+                        if len(valid) > 0:
+                            return (valid.min(), valid.max())
+                    except Exception:
+                        pass
+                    return (None, None)
             else:
                 logger.warning(f"Unsupported time data type: {time_vals.dtype}")
                 return (None, None)

--- a/dctools/data/datasets/dataloader.py
+++ b/dctools/data/datasets/dataloader.py
@@ -673,11 +673,19 @@ class EvaluationDataloader:
                             break
 
                         # ref_catalog = self.ref_catalogs[ref_alias]
-                        coord_system = ref_catalog.get_global_metadata().get("coord_system")
-                        if coord_system:
-                            is_observation = coord_system.is_observation_dataset()
+                        _ref_meta = ref_catalog.get_global_metadata()
+                        # Prefer the explicit is_observation flag stored in the catalog
+                        # metadata (set by Dataset.__init__ and respecting any config
+                        # override such as `observation_dataset: false`).  Only fall back
+                        # to coord_system auto-detection when the flag is absent.
+                        if "is_observation" in _ref_meta:
+                            is_observation = bool(_ref_meta["is_observation"])
                         else:
-                            is_observation = False
+                            coord_system = _ref_meta.get("coord_system")
+                            if coord_system:
+                                is_observation = coord_system.is_observation_dataset()
+                            else:
+                                is_observation = False
 
                         if is_observation:
                             # Observation logic: filter observation catalog

--- a/dctools/data/datasets/dataset.py
+++ b/dctools/data/datasets/dataset.py
@@ -190,6 +190,8 @@ class BaseDataset:
                     # Ensure is_observation flag is set
                     if config.observation_dataset:
                         self.observation_dataset = config.observation_dataset
+                    elif isinstance(getattr(config, "observation_dataset", None), bool):
+                        self.observation_dataset = config.observation_dataset
                     else:
                         coord_sys = self._global_metadata.get("coord_system")
                         if coord_sys and hasattr(coord_sys, "is_observation_dataset"):
@@ -230,6 +232,14 @@ class BaseDataset:
                     self._paths = self.catalog.list_paths()
                     self.catalog_type = "from_catalog_file"
                     self._global_metadata = self.catalog.get_global_metadata()
+                    # Config-level override for is_observation takes priority over catalog
+                    # metadata.  Explicit `observation_dataset: false` in the YAML must
+                    # override a stale `is_observation: True` that was auto-detected and
+                    # written to the catalog on a previous run.
+                    _cfg_obs = getattr(config, "observation_dataset", None)
+                    if isinstance(_cfg_obs, bool):
+                        self.observation_dataset = _cfg_obs
+                        self._global_metadata["is_observation"] = _cfg_obs
                     loaded_from_catalog = True
                 except Exception as exc:
                     logger.warning(
@@ -273,12 +283,23 @@ class BaseDataset:
                 self.catalog_type = ""
 
         if not loaded_from_catalog:
-            logger.info("No local catalog found. Loading metadata from remote source.")
+            _label = f"📡  Building catalog  —  {config.alias}"
+            _body  = "Fetching metadata from remote source …"
+            _w = max(len(_label), len(_body)) + 4
+            logger.opt(colors=True).info(
+                f"\n<cyan>┌{'─' * _w}┐\n"
+                f"│  <bold>{_label}</bold>{' ' * (_w - 2 - len(_label))}│\n"
+                f"│  <dim>{_body}</dim>{' ' * (_w - 2 - len(_body))}│\n"
+                f"└{'─' * _w}┘</cyan>"
+            )
             self._metadata = self.connection_manager.list_files_with_metadata()  # Retrieve metadata
             self._global_metadata = self.get_global_metadata()
             if self._global_metadata is None:
                 self._global_metadata = {}
             if config.observation_dataset:
+                self.observation_dataset = config.observation_dataset
+            elif isinstance(getattr(config, "observation_dataset", None), bool):
+                # Explicit `observation_dataset: false` in config — do not auto-detect
                 self.observation_dataset = config.observation_dataset
             else:
                 self.observation_dataset = self.get_coord_system().is_observation_dataset()

--- a/dctools/data/datasets/dc_catalog.py
+++ b/dctools/data/datasets/dc_catalog.py
@@ -88,8 +88,8 @@ class CatalogEntry:
         """Convert catalog entry to dictionary."""
         try:
             dct = asdict(self)
-            dct["date_start"] = self.date_start.isoformat()
-            dct["date_end"] = self.date_end.isoformat()
+            dct["date_start"] = self.date_start.isoformat() if self.date_start is not None else None
+            dct["date_end"] = self.date_end.isoformat() if self.date_end is not None else None
             normalized_geometry = self._normalize_geometry(self.geometry)
             if normalized_geometry is not None:
                 dct["geometry"] = mapping(normalized_geometry)
@@ -231,6 +231,7 @@ class DatasetCatalog:
                         props["geometry"] = geom_obj
                     else:
                         logger.warning(f"Feature without geometry : {props['path']}, skipping.")
+                        props["geometry"] = None
                 return props
             except Exception as exc:
                 logger.warning(f"Could not parse feature: {feat} ({exc})")

--- a/dctools/dcio/loader.py
+++ b/dctools/dcio/loader.py
@@ -57,6 +57,33 @@ def choose_chunks_automatically(
     return suggested
 
 
+def _fix_nanosecond_time(ds: xr.Dataset) -> xr.Dataset:
+    """Convert time variables stored as 'nanoseconds since <epoch>' to datetime64[ns].
+
+    xarray/cftime cannot decode 'nanoseconds' as a CF time unit.  When a zarr
+    store is opened with ``decode_times=False`` this helper detects integer
+    variables whose ``units`` attribute starts with 'nanoseconds since' and
+    reinterprets their int64 values as numpy datetime64[ns] (which uses the
+    same epoch convention internally).
+    """
+    for var in list(ds.coords) + list(ds.data_vars):
+        v = ds[var]
+        units = v.attrs.get("units", "")
+        if "nanoseconds since" in units and np.issubdtype(v.dtype, np.integer):
+            # Use scheduler="synchronous" to avoid routing through the distributed
+            # client (which can be broken inside a cancelled/restarting worker and
+            # would raise ClosedClientError when .values triggers __array__).
+            raw_data = v.variable._data
+            if hasattr(raw_data, "compute"):
+                raw_np = raw_data.compute(scheduler="synchronous")
+            else:
+                raw_np = np.asarray(raw_data)
+            new_values = raw_np.astype("datetime64[ns]")
+            new_attrs = {k: val for k, val in v.attrs.items() if k not in ("units", "calendar")}
+            ds[var] = xr.Variable(v.dims, new_values, new_attrs)
+    return ds
+
+
 def list_all_group_paths(nc_path: str) -> List[str]:
     """List all group paths in a NetCDF file.
 
@@ -213,6 +240,7 @@ class FileLoader:
                 zarr_kwargs: Dict[str, Any] = {
                     "chunks": base_chunks,
                     "consolidated": True,
+                    "decode_times": xr.coders.CFDatetimeCoder(use_cftime=True),
                 }
                 if file_storage is not None:
                     for attempt in range(reading_retries):
@@ -223,17 +251,54 @@ class FileLoader:
                             ds = xr.open_zarr(store, **zarr_kwargs)
                             break  # success — do NOT open the store again on next iteration
                         except Exception as e:
-                            logger.warning(f"Reading attempt {attempt + 1} failed: {e}")
-                            if attempt == reading_retries - 1:
-                                raise
+                            err_str = str(e).lower()
+                            # Some SWOT files use 'nanoseconds since …' which is not a
+                            # valid CF unit — fall back to decode_times=False and fix up.
+                            if "nanoseconds" in err_str:
+                                try:
+                                    store = file_storage.get_mapper(file_path)
+                                    no_decode_kw = {**zarr_kwargs, "decode_times": False}
+                                    ds = _fix_nanosecond_time(xr.open_zarr(store, **no_decode_kw))
+                                    break
+                                except Exception as e2:
+                                    logger.warning(f"Reading attempt {attempt + 1} failed (nanoseconds fallback): {e2}")
+                                    if attempt == reading_retries - 1:
+                                        raise
+                            # If consolidated metadata is missing, retry without it
+                            elif "zmetadata" in err_str or "consolidated" in err_str or "nosuchkey" in err_str:
+                                try:
+                                    store = file_storage.get_mapper(file_path)
+                                    fallback_kw = {**zarr_kwargs, "consolidated": False}
+                                    ds = xr.open_zarr(store, **fallback_kw)
+                                    break
+                                except Exception as e2:
+                                    logger.warning(f"Reading attempt {attempt + 1} failed: {e2}")
+                                    if attempt == reading_retries - 1:
+                                        raise
+                            else:
+                                logger.warning(f"Reading attempt {attempt + 1} failed: {e}")
+                                if attempt == reading_retries - 1:
+                                    raise
                 else:
                     for attempt in range(reading_retries):
                         try:
                             ds = xr.open_zarr(file_path, **zarr_kwargs)
                             break
                         except Exception as e:
+                            err_str = str(e).lower()
+                            # Some SWOT files use 'nanoseconds since …' which is not a
+                            # valid CF unit — fall back to decode_times=False and fix up.
+                            if "nanoseconds" in err_str:
+                                try:
+                                    no_decode_kw = {**zarr_kwargs, "decode_times": False}
+                                    ds = _fix_nanosecond_time(xr.open_zarr(file_path, **no_decode_kw))
+                                    break
+                                except Exception as e2:
+                                    logger.warning(f"Reading attempt {attempt + 1} failed (nanoseconds fallback): {e2}")
+                                    if attempt == reading_retries - 1:
+                                        raise
                             # If consolidated metadata is missing, retry without it
-                            if "zmetadata" in str(e).lower() or "consolidated" in str(e).lower():
+                            elif "zmetadata" in err_str or "consolidated" in err_str:
                                 try:
                                     fallback_kw = {**zarr_kwargs, "consolidated": False}
                                     ds = xr.open_zarr(file_path, **fallback_kw)

--- a/dctools/metrics/evaluator.py
+++ b/dctools/metrics/evaluator.py
@@ -610,6 +610,22 @@ def _worker_full_cleanup() -> bool:
     return True
 
 
+def _get_worker_rss_bytes() -> int:
+    """Return the RSS (Resident Set Size) of the current worker process in bytes.
+
+    Reads ``/proc/self/status`` on Linux.  Returns 0 on any error or on
+    platforms where the file is unavailable (macOS, Windows).
+    """
+    try:
+        with open("/proc/self/status") as _f:
+            for _line in _f:
+                if _line.startswith("VmRSS:"):
+                    return int(_line.split()[1]) * 1024  # kB → bytes
+    except Exception:
+        pass
+    return 0
+
+
 def _cap_worker_threads(max_threads: int = 1) -> None:
     """Limit per-worker thread parallelism for BLAS/OpenMP/pyinterp.
 
@@ -1263,9 +1279,29 @@ def compute_metric(
                                         n_points_dim,
                                         _time_var.size,
                                     )
+                                    # per-chunk zarr I/O timeout (seconds)
+                                    _CHUNK_TIMEOUT_S = int(os.environ.get(
+                                        "DCTOOLS_SIDECAR_CHUNK_TIMEOUT", "60"
+                                    ))
                                     try:
+                                        # ── Atomic write: tmp + rename ──────
+                                        # Multiple workers (4 for SWOT) may
+                                        # enter this fallback simultaneously
+                                        # when time_index.npy is absent.
+                                        # Writing directly to _time_npy with
+                                        # open_memmap(mode="w+") truncates the
+                                        # file, so concurrent workers see a
+                                        # partial/empty file → silent
+                                        # corruption.  Write to a per-PID temp
+                                        # file first, then os.replace() (atomic
+                                        # on POSIX) so readers always see a
+                                        # complete file.
+                                        _time_npy_tmp = (
+                                            _time_npy
+                                            + f".tmp.{os.getpid()}"
+                                        )
                                         _time_mmap = np.lib.format.open_memmap(
-                                            _time_npy,
+                                            _time_npy_tmp,
                                             mode="w+",
                                             dtype="datetime64[ns]",
                                             shape=(_n_total,),
@@ -1276,13 +1312,14 @@ def compute_metric(
                                             _chunk = _time_var.isel(
                                                 {n_points_dim: slice(_s, _e)}
                                             )
-                                            _cv = (
-                                                _chunk.compute(
-                                                    scheduler="synchronous"
+                                            if hasattr(_chunk, "compute"):
+                                                _cv = _compute_with_timeout(
+                                                    _chunk,
+                                                    timeout_s=_CHUNK_TIMEOUT_S,
+                                                    scheduler="synchronous",
                                                 ).values
-                                                if hasattr(_chunk, "compute")
-                                                else _chunk.values
-                                            )
+                                            else:
+                                                _cv = _chunk.values
                                             _cv = np.asarray(_cv)
                                             if np.issubdtype(
                                                 _cv.dtype, np.integer
@@ -1299,6 +1336,10 @@ def compute_metric(
                                             _time_mmap[_s:_e] = _cv
                                             del _cv, _chunk
                                         del _time_mmap
+                                        # Atomic rename; if another worker
+                                        # already wrote the file, we just
+                                        # overwrite it (same content).
+                                        os.replace(_time_npy_tmp, _time_npy)
                                         # Now mmap the freshly-built sidecar.
                                         _time_vals = np.load(
                                             _time_npy, mmap_mode="r"
@@ -1636,6 +1677,13 @@ def compute_metric(
 
         if ref_data is not None and ref_transform is not None:
             ref_data = ref_transform(ref_data)
+            # Unify chunks after transform to avoid "inconsistent chunks" errors
+            # (transforms like standardize/rename can produce mismatched chunk sizes).
+            if hasattr(ref_data, 'unify_chunks'):
+                try:
+                    ref_data = ref_data.unify_chunks()
+                except Exception:
+                    pass
             # Apply float32 reduction lazily *before* compute so the cast is
             # fused into the single compute pass — no separate in-memory copy
             # of the materialised arrays is needed afterwards.
@@ -1989,6 +2037,7 @@ class Evaluator:
         restart_frequency: int = 1,
         max_p_memory_increase: float = 0.2, # 20% increase default
         max_worker_memory_fraction: float = 0.85,
+        max_worker_rss_fraction: float = 1.0,
         resume: bool = False,
     ):
         """
@@ -2037,6 +2086,7 @@ class Evaluator:
         self.restart_frequency = restart_frequency
         self.max_p_memory_increase = max_p_memory_increase
         self.max_worker_memory_fraction = max_worker_memory_fraction
+        self.max_worker_rss_fraction = max_worker_rss_fraction
         # self.results = []
         self.ref_aliases = ref_aliases
         self.results_dir = results_dir
@@ -3130,11 +3180,43 @@ class Evaluator:
                                 >= float(self.max_p_memory_increase or 1.0)
                             )
 
-                            if _abs_exceeded or _rel_exceeded:
+                            # ── RSS-based check (unmanaged memory) ───────────
+                            # Dask's managed-memory tracker misses zarr/blosc
+                            # decompression buffers and xarray internals.
+                            # Reading /proc/self/status on each worker captures
+                            # the true footprint regardless of how the memory
+                            # was allocated.
+                            _rss_exceeded = False
+                            _rss_reason = ""
+                            _rss_threshold = float(self.max_worker_rss_fraction or 1.0)
+                            if _rss_threshold < 1.0:
+                                try:
+                                    _worker_rss = _client.run(_get_worker_rss_bytes)
+                                    _sched_info = _client.scheduler_info().get("workers", {})
+                                    for _waddr, _rss_b in _worker_rss.items():
+                                        _mem_lim = _sched_info.get(_waddr, {}).get("memory_limit", 0)
+                                        if _mem_lim > 0:
+                                            _rss_frac = _rss_b / _mem_lim
+                                            if _rss_frac >= _rss_threshold:
+                                                _rss_exceeded = True
+                                                _rss_reason = (
+                                                    f"RSS {_rss_b // (1024 ** 2)} MB / "
+                                                    f"{_mem_lim // (1024 ** 2)} MB "
+                                                    f"= {_rss_frac:.1%} >= "
+                                                    f"{_rss_threshold:.1%} "
+                                                    f"(worker {_waddr})"
+                                                )
+                                                break
+                                except Exception as _exc_rss:
+                                    logger.debug(f"RSS check failed: {_exc_rss!r}")
+
+                            if _abs_exceeded or _rel_exceeded or _rss_exceeded:
                                 _reason = (
                                     f"absolute {_cur_frac:.2%} >= "
                                     f"{self.max_worker_memory_fraction:.2%}"
                                     if _abs_exceeded
+                                    else _rss_reason
+                                    if _rss_exceeded
                                     else f"relative +{_rel_increase:.0%} >= "
                                     f"+{self.max_p_memory_increase:.0%} "
                                     f"(baseline={self.baseline_memory:.2%})"
@@ -3689,7 +3771,32 @@ class Evaluator:
                 _ref_fs_params = getattr(_ref_mgr, "params", None) if _ref_mgr is not None else None
                 _ref_s3fs = getattr(_ref_fs_params, "fs", None)
                 if _ref_s3fs is None:
-                    return
+                    # params.fs may have been nullified by clean_for_serialization
+                    # (which mutates the original when deep_copy fails for non-picklable
+                    # objects like s3fs).  Re-create the filesystem from stored credentials.
+                    _r_key = getattr(_ref_fs_params, "key", None) or getattr(_ref_fs_params, "s3_key", None)
+                    _r_secret = getattr(_ref_fs_params, "secret_key", None) or getattr(_ref_fs_params, "s3_secret_key", None)
+                    _r_ep = getattr(_ref_fs_params, "endpoint_url", None)
+                    if _r_key and _r_secret:
+                        try:
+                            import s3fs as _s3fs_mod
+                            _client_kw: dict = {}
+                            if _r_ep:
+                                _client_kw["endpoint_url"] = _r_ep
+                            _ref_s3fs = _s3fs_mod.S3FileSystem(
+                                key=_r_key,
+                                secret=_r_secret,
+                                client_kwargs=_client_kw,
+                            )
+                        except Exception as _fs_err:
+                            logger.warning(
+                                f"Could not recreate s3fs for ref prefetch ({ref_alias}): {_fs_err!r}"
+                            )
+                    if _ref_s3fs is None:
+                        logger.debug(
+                            f"Skipping ref prefetch for '{ref_alias}': no s3fs filesystem available."
+                        )
+                        return
 
                 from pathlib import Path as _PfRef
                 import shutil as _sh_ref
@@ -4894,8 +5001,13 @@ class Evaluator:
             # Track the last time a task completed (initialised to start).
             _last_progress: list = [time.time()]
             # After this many seconds with zero new completions -> cancel all.
-            _STALL_TIMEOUT = 1200  # 20 minutes — SWOT per-worker preprocessing can be slow
-            _MAX_WATCHDOG_RETRIES = 3  # max times a single task can be resubmitted after watchdog cancel
+            _STALL_TIMEOUT = 600  # 10 minutes — SWOT per-worker preprocessing can be slow; but 20 min was too long to wait per hung-task cycle
+            # After this many seconds for a *single* task -> cancel it proactively,
+            # even if other tasks are still making progress (catches frozen workers
+            # that stop heartbeating but whose process stays alive, which the
+            # batch-level stall watchdog cannot see).
+            _TASK_TIMEOUT = 900  # 15 minutes per task
+            _MAX_WATCHDOG_RETRIES = 2  # max times a single task can be resubmitted after watchdog cancel (total dead time ≤ (2+2)×600s=2400s)
             _retry_count: Dict[int, int] = {}  # task_index -> number of watchdog retries so far
 
             # Log the inevitable "tail" once: when pending tasks <= execution slots,
@@ -4908,7 +5020,7 @@ class Evaluator:
                     return
                 _last_state_log_s[0] = elapsed_s
                 try:
-                    info = _client.scheduler_info()
+                    info = _client.scheduler_info(timeout=10)
                     workers = info.get("workers", {})
                     paused = 0
                     max_frac = 0.0
@@ -4956,7 +5068,40 @@ class Evaluator:
                                 "CPU drop is expected here; remaining time is dominated by the slowest tasks."  # noqa: E501
                             )
 
-                        _maybe_log_cluster_state(_elapsed, _pending)
+                        # ── Per-task watchdog: cancel any single future running too long ──
+                        # Catches workers that freeze mid-task (stop heartbeating) while
+                        # other workers keep completing tasks — invisible to the batch-level
+                        # stall watchdog below.
+                        # NOTE: runs BEFORE _maybe_log_cluster_state so that a blocked
+                        # scheduler_info() call can never delay the watchdogs.
+                        _now_mono = time.monotonic()
+                        _per_task_cancelled: List[Any] = []
+                        for _tf, _ti in list(_active.items()):
+                            _age = _now_mono - _submitted_at.get(_tf, _now_mono)
+                            if _age >= _TASK_TIMEOUT:
+                                _prev = _retry_count.get(_ti, 0)
+                                if _prev < _MAX_WATCHDOG_RETRIES:
+                                    logger.warning(
+                                        f"{ref_alias}: task {_ti} has been running for "
+                                        f"{_age:.0f}s — cancelling (per-task timeout, "
+                                        f"will resubmit attempt {_prev + 2}/{_MAX_WATCHDOG_RETRIES + 1})"
+                                    )
+                                else:
+                                    logger.error(
+                                        f"{ref_alias}: task {_ti} has been running for "
+                                        f"{_age:.0f}s — cancelling (per-task timeout, "
+                                        f"retries exhausted)"
+                                    )
+                                _per_task_cancelled.append(_tf)
+                        if _per_task_cancelled:
+                            for _tf in _per_task_cancelled:
+                                try:
+                                    _tf.cancel()
+                                except Exception:
+                                    pass
+                            # Reset the batch-level stall timer so it does not
+                            # fire immediately after these per-task cancellations.
+                            _last_progress[0] = time.time()
 
                         # ── Watchdog: cancel futures if no progress ──────────
                         _stall_s = time.time() - _last_progress[0]
@@ -4986,6 +5131,13 @@ class Evaluator:
                                     pass
                             # Reset timer so we don't cancel again immediately.
                             _last_progress[0] = time.time()
+
+                        # ── Cluster state log (non-critical, runs last) ──────
+                        # Intentionally placed AFTER both watchdogs: if
+                        # scheduler_info() blocks (e.g. scheduler unreachable),
+                        # it cannot delay the per-task or batch stall watchdogs
+                        # above.  scheduler_info() is also given a short timeout.
+                        _maybe_log_cluster_state(_elapsed, _pending)
                     except Exception as _exc_hb:
                         logger.error(f"Heartbeat/watchdog thread error: {_exc_hb!r}")
 

--- a/dctools/metrics/oceanbench_metrics.py
+++ b/dctools/metrics/oceanbench_metrics.py
@@ -131,10 +131,18 @@ def _compute_spatial_per_bins(
     n_lon_bins = len(lon_bins) - 1
     n_bins_total = n_lat_bins * n_lon_bins
 
-    lat_idx = np.clip(np.digitize(lat_coord, lat_bins) - 1, 0, n_lat_bins - 1)  # (nlat,)
-    lon_idx = np.clip(np.digitize(lon_coord, lon_bins) - 1, 0, n_lon_bins - 1)  # (nlon,)
-    # Broadcast to 2D and flatten: shape (nlat * nlon,)
-    combined_idx = (lat_idx[:, None] * n_lon_bins + lon_idx[None, :]).ravel()
+    lat_idx = np.clip(np.digitize(lat_coord, lat_bins) - 1, 0, n_lat_bins - 1)
+    lon_idx = np.clip(np.digitize(lon_coord, lon_bins) - 1, 0, n_lon_bins - 1)
+    # Build flat bin index mapping each grid point to its (lat_bin, lon_bin) cell.
+    # For 2D curvilinear grids (lat_coord.ndim == 2), lat_idx and lon_idx already
+    # have shape (nlat, nlon) — element-wise multiplication avoids a catastrophic
+    # (nlat, 1, nlon) × (1, nlat, nlon) broadcast that would allocate nlat² × nlon
+    # elements (e.g. 881² × 609 ≈ 3.8 GB for a typical Arctic model grid).
+    if lat_coord.ndim == 2:
+        combined_idx = (lat_idx * n_lon_bins + lon_idx).ravel()
+    else:
+        # 1-D lat/lon axes: broadcast to a 2D grid then flatten
+        combined_idx = (lat_idx[:, None] * n_lon_bins + lon_idx[None, :]).ravel()
 
     # Determine variables to process
     var_names = [v for v in eval_variables if v in pred_ds.data_vars and v in ref_ds.data_vars]
@@ -183,47 +191,122 @@ def _compute_spatial_per_bins(
             if depth_index is not None:
                 if ref_da.sizes.get("depth", 0) <= depth_index:
                     continue
-                try:
-                    pred_slice = pred_da.isel(depth=depth_index).transpose("lat", "lon")
-                    ref_slice = ref_da.isel(depth=depth_index).transpose("lat", "lon")
-                except Exception:
-                    continue
                 depth_bin: Optional[Dict[str, Any]] = _depth_bin(depth_index)
+                _pred_base = pred_da.isel(depth=depth_index)
+                _ref_base = ref_da.isel(depth=depth_index)
             else:
+                depth_bin = None
+                _pred_base = pred_da
+                _ref_base = ref_da
+
+            # ── Get data arrays, handling 2D curvilinear grids ──────────────
+            # First try transpose to (lat, lon) for regular lat/lon dimension grids.
+            # Fall back to native (y, x) order when lat/lon are auxiliary 2D coordinates.
+            pred_arr = None
+            ref_arr = None
+            try:
+                pred_arr = _pred_base.transpose("lat", "lon").values.astype(np.float64)
+                ref_arr = _ref_base.transpose("lat", "lon").values.astype(np.float64)
+            except Exception:
                 try:
-                    pred_slice = pred_da.transpose("lat", "lon")
-                    ref_slice = ref_da.transpose("lat", "lon")
+                    pred_arr = _pred_base.values.astype(np.float64).squeeze()
+                    ref_arr = _ref_base.values.astype(np.float64).squeeze()
                 except Exception:
                     continue
-                depth_bin = None
 
-            pred_arr = pred_slice.values.astype(np.float64)
-            ref_arr = ref_slice.values.astype(np.float64)
-            if pred_arr.shape != ref_arr.shape or pred_arr.ndim != 2:
+            if pred_arr is None or pred_arr.ndim != 2:
                 continue
 
-            # ── Vectorised accumulation ──────────────────────────────────────
-            flat_pred = pred_arr.ravel()
-            flat_ref = ref_arr.ravel()
-            valid = ~(np.isnan(flat_pred) | np.isnan(flat_ref))
-            if not valid.any():
-                continue
+            # ── Same-grid path: direct point-wise RMSE per bin ───────────────
+            if pred_arr.shape == ref_arr.shape:
+                flat_pred = pred_arr.ravel()
+                flat_ref = ref_arr.ravel()
+                if flat_pred.size != combined_idx.size:
+                    continue
+                valid = ~(np.isnan(flat_pred) | np.isnan(flat_ref))
+                if not valid.any():
+                    continue
 
-            diff_sq = (flat_pred[valid] - flat_ref[valid]) ** 2
-            valid_idx = combined_idx[valid]
+                diff_sq = (flat_pred[valid] - flat_ref[valid]) ** 2
+                valid_idx = combined_idx[valid]
+                counts = np.bincount(valid_idx, minlength=n_bins_total)
+                sum_sq = np.bincount(valid_idx, weights=diff_sq, minlength=n_bins_total)
+                nz_flat = np.flatnonzero(counts)
+                if nz_flat.size == 0:
+                    continue
+                nz_rmse = np.sqrt(sum_sq[nz_flat] / counts[nz_flat])
+                nz_counts = counts[nz_flat]
 
-            # np.bincount is O(N) and ~10× faster than np.add.at for dense integer indices
-            counts = np.bincount(valid_idx, minlength=n_bins_total)
-            sum_sq = np.bincount(valid_idx, weights=diff_sq, minlength=n_bins_total)
+            else:
+                # ── Different-grid path: per-bin mean then RMSE ──────────────
+                # Pred and ref are on different grids (e.g. TOPAZ 881×609 vs
+                # AMSR2 3584×2432). Build combined_idx for each grid separately,
+                # bin-average each, then compute RMSE between bin averages.
+                if ref_arr.ndim != 2:
+                    continue
 
-            # ── Emit one dict per non-empty bin ──────────────────────────────
-            nz_flat = np.flatnonzero(counts)
+                # Get ref lat/lon (may be in coords OR data_vars)
+                ref_lat_arr = None
+                ref_lon_arr = None
+                for _lat_src in (ref_ds.coords, getattr(ref_ds, "data_vars", {})):
+                    if "lat" in _lat_src and ref_lat_arr is None:
+                        ref_lat_arr = np.asarray(_lat_src["lat"].values, dtype=np.float64).squeeze()
+                    if "lon" in _lat_src and ref_lon_arr is None:
+                        ref_lon_arr = np.asarray(_lat_src["lon"].values, dtype=np.float64).squeeze()
+
+                if ref_lat_arr is None or ref_lon_arr is None:
+                    continue
+                # Normalise ref lat/lon to 2D → flatten
+                if ref_lat_arr.shape != ref_arr.shape:
+                    try:
+                        ref_lat_arr = np.broadcast_to(ref_lat_arr, ref_arr.shape).copy()
+                        ref_lon_arr = np.broadcast_to(ref_lon_arr, ref_arr.shape).copy()
+                    except Exception:
+                        continue
+
+                ref_lat_flat = ref_lat_arr.ravel()
+                ref_lon_flat = ref_lon_arr.ravel()
+                ref_flat = ref_arr.ravel()
+
+                ref_lat_idx = np.clip(np.digitize(ref_lat_flat, lat_bins) - 1, 0, n_lat_bins - 1)
+                ref_lon_idx = np.clip(np.digitize(ref_lon_flat, lon_bins) - 1, 0, n_lon_bins - 1)
+                ref_cidx = (ref_lat_idx * n_lon_bins + ref_lon_idx)
+
+                # Bin-average pred (using pred combined_idx)
+                pred_flat = pred_arr.ravel()
+                if pred_flat.size != combined_idx.size:
+                    continue
+                p_valid = ~np.isnan(pred_flat)
+                p_counts = np.bincount(combined_idx[p_valid], weights=None, minlength=n_bins_total)
+                p_sums = np.bincount(combined_idx[p_valid], weights=pred_flat[p_valid], minlength=n_bins_total)
+                with np.errstate(invalid="ignore", divide="ignore"):
+                    p_means = np.where(p_counts > 0, p_sums / p_counts, np.nan)
+
+                # Bin-average ref (using ref combined_idx)
+                r_valid = ~np.isnan(ref_flat)
+                r_counts = np.bincount(ref_cidx[r_valid], weights=None, minlength=n_bins_total)
+                r_sums = np.bincount(ref_cidx[r_valid], weights=ref_flat[r_valid], minlength=n_bins_total)
+                with np.errstate(invalid="ignore", divide="ignore"):
+                    r_means = np.where(r_counts > 0, r_sums / r_counts, np.nan)
+
+                # RMSE between bin-averages for bins covered by both grids
+                both = (~np.isnan(p_means)) & (~np.isnan(r_means))
+                if not both.any():
+                    continue
+                sum_sq = np.where(both, (p_means - r_means) ** 2, 0.0)
+                counts = np.where(both, np.minimum(p_counts, r_counts).astype(np.int64), 0)
+                # Treat each bin as having count from min of pred/ref coverage
+                nz_flat = np.flatnonzero(both)
+                if nz_flat.size == 0:
+                    continue
+                nz_rmse = np.sqrt(sum_sq[nz_flat])
+                nz_counts = counts[nz_flat]
+
+            # ── Shared: emit one dict per non-empty bin ─────────────────────
             if nz_flat.size == 0:
                 continue
             nz_lat = nz_flat // n_lon_bins
             nz_lon = nz_flat % n_lon_bins
-            nz_rmse = np.sqrt(sum_sq[nz_flat] / counts[nz_flat])
-            nz_counts = counts[nz_flat]
 
             for k in range(nz_flat.size):
                 li = int(nz_lat[k])

--- a/dctools/processing/base.py
+++ b/dctools/processing/base.py
@@ -1411,7 +1411,7 @@ class BaseDCEvaluation:
                     continue
 
                 oceanbench_eval_variables = (
-                    [get_variable_alias(var) for var in common_vars] if common_vars else None
+                    [get_variable_alias(var) or var for var in common_vars] if common_vars else None
                 )
 
                 common_metrics = [
@@ -1537,6 +1537,7 @@ class BaseDCEvaluation:
                 restart_frequency=getattr(self.args, "restart_frequency", 1),
                 max_p_memory_increase=getattr(self.args, "max_p_memory_increase", 0.2),
                 max_worker_memory_fraction=getattr(self.args, "max_worker_memory_fraction", 0.85),
+                max_worker_rss_fraction=getattr(self.args, "max_worker_rss_fraction", 1.0),
                 resume=_resume,
             )
             _n_pred_total = len(dataset_references)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -85,16 +85,13 @@ Define evaluation workflows in YAML for reproducibility and version control.
 6. Save and analyze results
 ```
 
-## Recent Changes
+## Documentation Status
 
-This documentation has been updated to reflect the current state of the codebase (May 2026):
+Documentation content is actively maintained and periodically reviewed against the codebase.
 
-- ✅ Complete installation instructions with troubleshooting
-- ✅ Comprehensive quick start guide with working code examples
-- ✅ Full API reference for all modules
-- ✅ Architecture documentation
-- ✅ Common use cases and patterns
-- ✅ Configuration file examples
+- Core guides are available for installation, quickstart, API, and challenge workflows.
+- Some advanced sections are conceptual and may require adaptation for custom pipelines.
+- When in doubt, prefer explicit imports from module files and the challenge entrypoint scripts.
 
 ## Getting Help
 
@@ -136,4 +133,4 @@ package_docs/api.md
 data_challenges/dc_index.md
 ```
 
-**Last updated**: May 2026 | **Status**: Complete and current
+**Last reviewed**: May 2026 | **Status**: Maintained

--- a/docs/source/package_docs/api.md
+++ b/docs/source/package_docs/api.md
@@ -33,7 +33,7 @@ Complete API documentation for all dctools modules.
 ### Key Functions
 
 - `DataSaver.save_dataset()` - Save data to various formats
-- `DataLoader` - Load data from disk
+- `FileLoader` - Load various file formats (NetCDF, Zarr, HDF5)
 - `choose_chunks_automatically()` - Optimize data chunking
 
 ## Metrics
@@ -114,19 +114,23 @@ Here are the typical imports for common tasks:
 
 ```python
 # Data loading
-from dctools.data import EvaluationDataloader, CoordinateSystem
+from dctools.data.coordinates import CoordinateSystem
+from dctools.data.datasets.dataloader import EvaluationDataloader
 
 # Metrics computation
-from dctools.metrics import MetricComputer, Evaluator
+from dctools.metrics.evaluator import Evaluator
+from dctools.metrics.metrics import MetricComputer
 
 # Data processing
-from dctools.processing import interpolate_dataset, BaseDCEvaluation
+from dctools.processing.base import BaseDCEvaluation
+from dctools.processing.interpolation import interpolate_dataset
 
 # I/O operations
-from dctools.dcio import DataSaver, DataLoader
+from dctools.dcio.loader import FileLoader, choose_chunks_automatically
+from dctools.dcio.saver import DataSaver
 
 # Utilities
-from dctools.utilities import init_dask_cluster
+from dctools.utilities.args_config import load_args_and_config
 ```
 
 ## Module Overview
@@ -134,7 +138,7 @@ from dctools.utilities import init_dask_cluster
 | Module | Purpose | Key Classes |
 |--------|---------|-------------|
 | `dctools.data` | Data loading & coordinate handling | `EvaluationDataloader`, `CoordinateSystem` |
-| `dctools.dcio` | Data I/O operations | `DataSaver`, `DataLoader` |
+| `dctools.dcio` | Data I/O operations | `DataSaver`, `FileLoader` |
 | `dctools.metrics` | Metric computation | `MetricComputer`, `Evaluator` |
 | `dctools.processing` | Data processing pipelines | `BaseDCEvaluation`, `interpolate_dataset` |
 | `dctools.utilities` | General utilities | Various helper functions |

--- a/docs/source/package_docs/dctools_index.md
+++ b/docs/source/package_docs/dctools_index.md
@@ -106,7 +106,7 @@ Handles data reading and writing.
 
 **Key Functions:**
 - `DataSaver.save_dataset()` - Save to NetCDF/Zarr
-- `DataLoader` - Load various formats
+- `FileLoader` - Load various formats
 - `choose_chunks_automatically()` - Optimize chunking
 
 **Formats supported:**
@@ -162,15 +162,24 @@ Development and debugging utilities.
 Validate model output against Argo profiles:
 
 ```python
-from dctools.data import EvaluationDataloader
-from dctools.metrics import MetricComputer
+import xarray as xr
 
-loader = EvaluationDataloader()
-model = loader.load_dataset(source="cmems")
-observations = loader.load_dataset(source="argo")
+from dctools.data.coordinates import CoordinateSystem
+from dctools.metrics.metrics import MetricComputer
 
-computer = MetricComputer()
-metrics = computer.compute(model, observations)
+model = xr.open_dataset("model.nc")
+observations = xr.open_dataset("observations.nc")
+
+model_coords = CoordinateSystem(model)
+obs_coords = CoordinateSystem(observations)
+
+computer = MetricComputer(eval_variables=["so", "thetao"])
+metrics = computer.compute(
+   pred_data=model,
+   ref_data=observations,
+   pred_coords=model_coords,
+   ref_coords=obs_coords,
+)
 ```
 
 ### Use Case 2: Large-Scale Evaluation
@@ -179,14 +188,14 @@ Evaluate on a Dask cluster across multiple regions:
 
 ```python
 from dask.distributed import Client
-from dctools.metrics import Evaluator
+
+from dc2.evaluation.evaluation import DC2Evaluation
+from dctools.utilities.args_config import load_args_and_config
 
 with Client(n_workers=10):
-    evaluator = Evaluator()
-    results = evaluator.evaluate(
-        datasets=[ds1, ds2, ds3],
-        reference=reference
-    )
+   args = load_args_and_config("dc2/config/dc2.yaml")
+   evaluator = DC2Evaluation(args)
+   evaluator.run_eval()
 ```
 
 ### Use Case 3: Data Challenge Setup
@@ -208,7 +217,7 @@ evaluation:
 ```
 
 ```bash
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
 ## Architecture Patterns

--- a/docs/source/usage/architecture.md
+++ b/docs/source/usage/architecture.md
@@ -38,7 +38,7 @@ This document describes the architecture and design patterns used in dc-tools.
 │                                                              │
 │  I/O (dcio/)                                                │
 │  ├─ DataSaver (NetCDF/Zarr)                                │
-│  └─ DataLoader                                              │
+│  └─ FileLoader                                              │
 │                                                              │
 │  Utilities (utilities/)                                     │
 │  ├─ Configuration Parsing                                  │
@@ -181,9 +181,11 @@ Each extends with challenge-specific:
 
 ```python
 class EvaluationDataloader:
-    """Main entry point for data loading"""
-    def load_dataset(source: str) → xr.Dataset
-    def _transform_coordinates(ds) → xr.Dataset
+    """Iterable dataloader; instantiated via a params dict by the runner."""
+    # key public interface
+    def __iter__(self) → Generator[List[Dict], None, None]
+    def open_pred(self, pred_entry) → xr.Dataset
+    def open_ref(self, ref_entry, ref_alias) → xr.Dataset
 
 class CoordinateSystem:
     """Detect and normalize coordinates"""
@@ -378,8 +380,9 @@ config:
 
 ```python
 # Uses thread pool (no GIL bottleneck for Dask)
-loader = EvaluationDataloader()
-metrics = loader.evaluate()  # Synchronous
+from dctools.metrics.evaluator import Evaluator
+evaluator = Evaluator(...)
+results = evaluator.evaluate()  # Synchronous
 ```
 
 ### Distributed Execution
@@ -389,8 +392,8 @@ from dask.distributed import Client
 
 with Client(n_workers=10, threads_per_worker=2):
     # Same code runs on cluster
-    loader = EvaluationDataloader()
-    metrics = loader.evaluate()  # Distributed
+    evaluator = Evaluator(...)
+    results = evaluator.evaluate()  # Distributed
 ```
 
 **No code changes needed - Dask handles distribution.**
@@ -459,9 +462,9 @@ Developers can extend dc-tools at several points:
 ### 1. Custom Data Source
 
 ```python
-from dctools.data import ConnectionManager
+from dctools.data.connection.connection_manager import BaseConnectionManager
 
-class CustomBackend(ConnectionManager):
+class CustomBackend(BaseConnectionManager):
     def connect(config):
         # Custom connection logic
         return xr.Dataset(...)
@@ -470,7 +473,7 @@ class CustomBackend(ConnectionManager):
 ### 2. Custom Metric
 
 ```python
-from dctools.metrics import MetricComputer
+from dctools.metrics.metrics import MetricComputer
 
 class CustomMetric(MetricComputer):
     def _custom_metric(pred, ref):
@@ -481,7 +484,7 @@ class CustomMetric(MetricComputer):
 ### 3. Custom Evaluation
 
 ```python
-from dctools.processing import BaseDCEvaluation
+from dctools.processing.base import BaseDCEvaluation
 
 class CustomEvaluation(BaseDCEvaluation):
     def _process(self):

--- a/docs/source/usage/config.md
+++ b/docs/source/usage/config.md
@@ -358,17 +358,14 @@ output:
 Execute evaluation using the configuration file:
 
 ```bash
-# Basic usage
-poetry run python -m dctools run config.yaml
+# Run DC2 with the default config (dc2/config/dc2.yaml)
+poetry run python dc2/evaluate.py -d ./data -c dc2
 
-# With custom output directory
-poetry run python -m dctools run config.yaml --output-dir ./custom_results/
+# Run DC2 with another config name (dc2/config/<name>.yaml)
+poetry run python dc2/evaluate.py -d ./data -c dc2_edito
 
-# Verbose output
-poetry run python -m dctools run config.yaml --verbose
-
-# Dry run (show what would be executed)
-poetry run python -m dctools run config.yaml --dry-run
+# Optional: write logs to a file
+poetry run python dc2/evaluate.py -d ./data -c dc2 -l ./logs/dc2.log
 ```
 
 ## Environment Variables
@@ -385,7 +382,7 @@ export S3_ENDPOINT=s3.example.com
 export ARGO_CACHEDIR=/custom/cache
 
 # Run evaluation
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
 ## Advanced Patterns
@@ -447,9 +444,11 @@ evaluation:
 
 **Issue**: Configuration not found
 ```bash
-# Make sure path is correct
-poetry run python -m dctools run --help
-poetry run python -m dctools run ./config.yaml  # Use ./
+# Check available CLI arguments
+poetry run python dc2/evaluate.py --help
+
+# Config name must map to: dc2/config/<config_name>.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
 **Issue**: Invalid variable names

--- a/docs/source/usage/index.md
+++ b/docs/source/usage/index.md
@@ -23,10 +23,9 @@ Quick references for specific tasks:
 ### Data Loading
 
 ```python
-from dctools.data import EvaluationDataloader
+import xarray as xr
 
-loader = EvaluationDataloader()
-data = loader.load_dataset(source="argo")  # or "cmems", "s3"
+data = xr.open_dataset("reference.nc")
 ```
 
 See [Quick Start - Loading Data](quickstart.md#2-loading-data)
@@ -34,9 +33,9 @@ See [Quick Start - Loading Data](quickstart.md#2-loading-data)
 ### Processing Data
 
 ```python
-from dctools.processing import interpolate_dataset
+from dctools.processing.interpolation import interpolate_dataset
 
-interpolated = interpolate_dataset(model_data, reference_grid)
+interpolated = interpolate_dataset(model_data, target_grid=reference_grid)
 ```
 
 See [Quick Start - Processing Data](quickstart.md#4-processing-data)
@@ -44,10 +43,10 @@ See [Quick Start - Processing Data](quickstart.md#4-processing-data)
 ### Computing Metrics
 
 ```python
-from dctools.metrics import MetricComputer
+from dctools.metrics.metrics import MetricComputer
 
 computer = MetricComputer()
-metrics = computer.compute(prediction, reference, ["rmse", "mae"])
+metrics = computer.compute(pred_data=prediction, ref_data=reference)
 ```
 
 See [Quick Start - Computing Metrics](quickstart.md#5-computing-metrics)
@@ -76,7 +75,7 @@ Learn to configure evaluation workflows:
 ### Run from Configuration
 
 ```bash
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
 ## Understanding Architecture
@@ -121,7 +120,7 @@ See [Architecture - Performance](architecture.md#performance-characteristics)
 Extend dc-tools for your needs:
 
 ```python
-from dctools.processing import BaseDCEvaluation
+from dctools.processing.base import BaseDCEvaluation
 
 class MyEvaluation(BaseDCEvaluation):
     # Custom logic here
@@ -151,7 +150,7 @@ See [Architecture - Troubleshooting](architecture.md#troubleshooting-architectur
 ```bash
 # 1. Create config.yaml (5 min)
 # 2. Run
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 # 3. Check results
 cat results/metrics.json
 ```
@@ -167,7 +166,7 @@ dask-worker scheduler_address:8786 &
 
 # 2. Configure for cluster (in config.yaml)
 # 3. Run
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 
 # 4. Monitor progress
 # Visit http://localhost:8787 for Dask dashboard
@@ -179,7 +178,7 @@ Time: hours to days depending on dataset size
 
 ```python
 # 1. Create challenge class
-from dctools.processing import BaseDCEvaluation
+from dctools.processing.base import BaseDCEvaluation
 
 class MyChallenge(BaseDCEvaluation):
     VARIABLES = ['MY_VAR']

--- a/docs/source/usage/quickstart.md
+++ b/docs/source/usage/quickstart.md
@@ -1,6 +1,8 @@
 # Quick Start Guide
 
-This guide will help you get started with dc-tools in 5 minutes. For detailed information, refer to the [API Reference](../package_docs/api.md).
+This guide shows a minimal workflow aligned with the current package layout.
+For detailed behavior and configuration fields, see the
+[API Reference](../package_docs/api.md).
 
 ## 1. Basic Setup
 
@@ -8,299 +10,99 @@ After [installing dc-tools](../package_docs/installation.md), activate your envi
 
 ```bash
 conda activate dctools
-python -c "import dctools; print('✓ dc-tools ready')"
+python -c "import dctools; print('dc-tools ready')"
 ```
 
-## 2. Loading Data
-
-### Load from Argo (in-situ profiles)
-
-```python
-from dctools.data import EvaluationDataloader
-
-loader = EvaluationDataloader()
-
-# Load Argo data
-argo_profiles = loader.load_dataset(
-    source="argo",
-    region="north_atlantic",  # optional: specify region
-    time_range=("2023-01-01", "2023-12-31")
-)
-
-print(argo_profiles)
-```
-
-### Load from CMEMS (model output)
-
-```python
-# Load CMEMS data
-model_data = loader.load_dataset(
-    source="cmems",
-    dataset="global_forecast",
-    variables=["SO", "THETAO", "ZOS"],  # Salinity, Temperature, Sea Surface Height
-    region="global"
-)
-
-print(model_data)
-```
-
-### Load from local files
+## 2. Load Datasets
 
 ```python
 import xarray as xr
 
-# Load from NetCDF
-data = xr.open_dataset("yourfile.nc")
-
-# Or from Zarr
-data = xr.open_zarr("yourfile.zarr")
+# Load from local files (NetCDF or Zarr)
+pred_ds = xr.open_dataset("prediction.nc")
+ref_ds = xr.open_dataset("reference.nc")
 ```
 
-## 3. Data Inspection & Coordinate Handling
-
-### Inspect dataset
+If you need automatic format/group handling, use:
 
 ```python
-from dctools.data import CoordinateSystem
+from dctools.dcio.loader import FileLoader
 
-# View dataset info
-print(argo_profiles)
-print(f"Variables: {list(argo_profiles.data_vars)}")
-print(f"Coordinates: {list(argo_profiles.coords)}")
-
-# Auto-detect and normalize coordinates
-cs = CoordinateSystem(argo_profiles)
-standardized = cs.get_target_dimensions()
-print(f"Standard coordinates: {standardized}")
+pred_ds = FileLoader.open_dataset_auto("prediction.nc")
+ref_ds = FileLoader.open_dataset_auto("reference.nc")
 ```
 
-### Get depth levels
+## 3. Inspect Coordinates
 
 ```python
-depth_levels = cs.get_target_depth_values()
-print(f"Available depths: {depth_levels}")
+from dctools.data.coordinates import CoordinateSystem
+
+pred_coords = CoordinateSystem(pred_ds)
+ref_coords = CoordinateSystem(ref_ds)
+
+print(pred_coords.get_target_dimensions())
+print(ref_coords.get_target_dimensions())
 ```
 
-## 4. Processing Data
-
-### Simple transformation
+## 4. Optional Interpolation
 
 ```python
-from dctools.data import EvaluationDataloader
+from dctools.processing.interpolation import interpolate_dataset
 
-# Normalize longitude to [-180, 180]
-processed = loader._transform_coordinates(model_data)
-```
-
-### Interpolate to a regular grid
-
-```python
-from dctools.processing import interpolate_dataset
-
-# Interpolate model output to observation grid
-interpolated = interpolate_dataset(
-    model_data,
-    target_grid=argo_profiles,
-    method="bilinear",
-    variables=["SO", "THETAO"]
-)
-
-print(f"Interpolated shape: {interpolated.dims}")
-```
-
-## 5. Computing Metrics
-
-### Calculate basic metrics
-
-```python
-from dctools.metrics import MetricComputer
-
-# Compute RMSE and MAE
-metric_computer = MetricComputer(
-    variables=["SO", "THETAO"],
-    mask_land=True
-)
-
-metrics = metric_computer.compute(
-    prediction=interpolated,
-    reference=argo_profiles,
-    metrics=["rmse", "mae", "bias"]
-)
-
-print(f"RMSE: {metrics['rmse']}")
-print(f"MAE: {metrics['mae']}")
-print(f"Bias: {metrics['bias']}")
-```
-
-### Per-region evaluation
-
-```python
-# Define regions (lat, lon boxes)
-regions = {
-    "north_atlantic": {
-        "lat": (30, 60),
-        "lon": (-80, 0)
-    },
-    "tropical": {
-        "lat": (-20, 20),
-        "lon": (-180, 180)
-    }
+# Target grid is a dictionary of coordinate vectors.
+target_grid = {
+    "lat": ref_ds["lat"].values,
+    "lon": ref_ds["lon"].values,
 }
 
-# Evaluate per region
-for region_name, bounds in regions.items():
-    regional_metrics = metric_computer.compute(
-        prediction=interpolated.sel(
-            lat=slice(bounds["lat"][0], bounds["lat"][1]),
-            lon=slice(bounds["lon"][0], bounds["lon"][1])
-        ),
-        reference=argo_profiles.sel(
-            lat=slice(bounds["lat"][0], bounds["lat"][1]),
-            lon=slice(bounds["lon"][0], bounds["lon"][1])
-        ),
-        metrics=["rmse"]
-    )
-    print(f"{region_name}: RMSE = {regional_metrics['rmse']}")
+pred_interp = interpolate_dataset(
+    pred_ds,
+    target_grid=target_grid,
+    interpolation_lib="pyinterp",
+)
 ```
 
-## 6. Distributed Evaluation (with Dask)
-
-### Setup Dask cluster
+## 5. Compute Metrics
 
 ```python
-from dask.distributed import Client
+from dctools.metrics.metrics import MetricComputer
 
-# Local cluster (4 workers)
-client = Client(n_workers=4, threads_per_worker=2, memory_limit='4GB')
+metric_computer = MetricComputer(eval_variables=["so", "thetao"])
 
-# Import dctools after Dask is set up
-from dctools.metrics import Evaluator
-
-# Evaluation now uses Dask automatically
-evaluator = Evaluator()
-results = evaluator.evaluate(
-    datasets=[model_data],
-    reference=argo_profiles
+results = metric_computer.compute(
+    pred_data=pred_interp,
+    ref_data=ref_ds,
+    pred_coords=pred_coords,
+    ref_coords=ref_coords,
 )
 
 print(results)
-client.close()
 ```
 
-## 7. Saving Results
-
-### Save to NetCDF
+## 6. Save Outputs
 
 ```python
-from dctools.dcio import DataSaver
+from dctools.dcio.saver import DataSaver
 
-saver = DataSaver()
-
-saver.save_dataset(
-    interpolated,
-    "results.nc",
-    format="netcdf4"
-)
+DataSaver.save_dataset(pred_interp, "results.nc", file_format="netcdf")
+DataSaver.save_dataset(pred_interp, "results.zarr", file_format="zarr", mode="w")
 ```
 
-### Save to Zarr (better for large datasets)
+## 7. Run the DC2 Pipeline from Config
 
-```python
-saver.save_dataset(
-    interpolated,
-    "results.zarr",
-    format="zarr",
-    mode="w-"
-)
-```
-
-### Save evaluation results as JSON
-
-```python
-import json
-
-with open("metrics.json", "w") as f:
-    json.dump(metrics, f, indent=2, default=str)
-```
-
-## 8. Configuration-Driven Workflows
-
-For more complex evaluations, use YAML configuration:
-
-### Create `config.yaml`
-
-```yaml
-sources:
-  model:
-    type: gridded
-    path: s3://bucket/model_output.nc
-    variables: [SO, THETAO, ZOS]
-    
-  observations:
-    type: profiles
-    path: ./data/argo_profiles/
-    
-evaluation:
-  grid_spacing: 0.25
-  regions: [global, north_atlantic, tropical]
-  metrics: [rmse, mae, bias]
-  mask_land: true
-  
-output:
-  format: json
-  path: ./results/
-```
-
-### Run evaluation
+The challenge entrypoint is script-based:
 
 ```bash
-poetry run python -m dctools run config.yaml
+poetry run python dc2/evaluate.py -d ./data -c dc2
 ```
 
-## 9. Common Tasks
+Notes:
+- `-d/--data_directory` is required.
+- `-c/--config_name` selects `dc2/config/<config_name>.yaml`.
 
-### Check available variables
+## 8. Next Steps
 
-```python
-print(model_data.data_vars)
-print(argo_profiles.data_vars)
-```
-
-### Subset by time
-
-```python
-subset = model_data.sel(
-    time=slice("2023-06-01", "2023-08-31")
-)
-```
-
-### Subset by coordinates
-
-```python
-atlantic = model_data.sel(
-    lat=slice(30, 60),
-    lon=slice(-80, 0)
-)
-```
-
-### Check and increase memory
-
-```python
-import dask
-dask.config.set({'distributed.scheduler.worker-ttl': '1 hour'})
-dask.config.set({'memory.target-fraction': 0.8})
-```
-
-## 10. Next Steps
-
-- **[Installation Guide](../package_docs/installation.md)** - Detailed setup instructions
-- **[API Reference](../package_docs/api.md)** - Full API documentation
-- **[Data Challenges](../data_challenges/dc_index.md)** - Challenge-specific documentation
-- **[GitHub Issues](https://github.com/ppr-ocean-ia/dc-tools/issues)** - Report bugs or ask questions
-
-## 📚 Useful Resources
-
-- [Xarray Documentation](https://xarray.pydata.org/) - Working with labeled arrays
-- [Dask Documentation](https://dask.org/) - Distributed computing
-- [OceanBench](https://github.com/mercator-ocean/oceanbench) - Metrics library
-- [PPR Océan & Climat](https://www.ocean-climat.fr/) - Main initiative
+- **[Installation Guide](../package_docs/installation.md)** - Full setup and troubleshooting
+- **[Configuration Guide](config.md)** - YAML options and patterns
+- **[API Reference](../package_docs/api.md)** - Module-level documentation
+- **[Data Challenges](../data_challenges/dc_index.md)** - Challenge-specific pages

--- a/poetry.lock
+++ b/poetry.lock
@@ -1840,7 +1840,7 @@ pyyaml = ">=6.0.3"
 type = "git"
 url = "https://github.com/ocean-ai-data-challenges/dc_leaderboard"
 reference = "main"
-resolved_reference = "5d06c3045bf0d1abf556da96a6136f047ec883a8"
+resolved_reference = "2f54d9c56cb73562ce1bd204ebf1ffcd15598c06"
 
 [[package]]
 name = "debugpy"
@@ -5640,7 +5640,7 @@ develop = false
 
 [package.dependencies]
 aiohttp = ">=3.0.0"
-copernicusmarine = "2.2.2"
+copernicusmarine = ">=2.2.2"
 dask = {version = ">=2025.01.0", extras = ["distributed"]}
 gsw = ">=3.6.19,<4.0.0"
 loguru = "*"
@@ -5650,7 +5650,7 @@ numcodecs = "0.15.1"
 parcels = ">=3.1.2,<4.0.0"
 requests = ">=2.27.1"
 seaborn = ">=0.13.2,<0.14.0"
-xarray = ">=2024"
+xarray = ">=2025.7,<=2025.9.0"
 xskillscore = ">=0.0.27"
 zarr = "2.18.4"
 
@@ -5658,7 +5658,7 @@ zarr = "2.18.4"
 type = "git"
 url = "https://github.com/aitmohandk/oceanbench.git"
 reference = "main"
-resolved_reference = "fb1e63e1d916666ab2499f01b9a5da37f00af33d"
+resolved_reference = "dd7aff760b1d403ddb393ee66591487db5136540"
 
 [[package]]
 name = "omegaconf"
@@ -9313,29 +9313,29 @@ dev = ["pytest", "setuptools"]
 
 [[package]]
 name = "xarray"
-version = "2026.4.0"
+version = "2025.9.0"
 description = "N-D labeled arrays and datasets in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main", "custom"]
 files = [
-    {file = "xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08"},
-    {file = "xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b"},
+    {file = "xarray-2025.9.0-py3-none-any.whl", hash = "sha256:79f0e25fb39571f612526ee998ee5404d8725a1db3951aabffdb287388885df0"},
+    {file = "xarray-2025.9.0.tar.gz", hash = "sha256:7dd6816fe0062c49c5e9370dd483843bc13e5ed80a47a9ff10baff2b51e070fb"},
 ]
 
 [package.dependencies]
 numpy = ">=1.26"
-packaging = ">=24.2"
+packaging = ">=24.1"
 pandas = ">=2.2"
 
 [package.extras]
-accel = ["bottleneck", "flox (>=0.10)", "numba (>=0.62)", "numbagg (>=0.9)", "opt_einsum", "scipy (>=1.15)"]
+accel = ["bottleneck", "flox (>=0.9)", "numba (>=0.59)", "numbagg (>=0.8)", "numpy (<2.3)", "opt_einsum", "scipy (>=1.13)"]
 complete = ["xarray[accel,etc,io,parallel,viz]"]
 etc = ["sparse (>=0.15)"]
-io = ["cftime", "fsspec", "h5netcdf[h5py] (>=1.5.0)", "netCDF4 (>=1.6.0)", "pooch", "pydap", "scipy (>=1.15)", "zarr (>=3.0)"]
+io = ["cftime", "fsspec", "h5netcdf", "netCDF4 (>=1.6.0)", "pooch", "pydap", "scipy (>=1.13)", "zarr (>=2.18)"]
 parallel = ["dask[complete]"]
-types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-requests", "types-setuptools", "types-xlrd"]
-viz = ["cartopy (>=0.24)", "matplotlib (>=3.10)", "nc-time-axis", "seaborn"]
+types = ["pandas-stubs", "scipy-stubs", "types-PyYAML", "types-Pygments", "types-colorama", "types-decorator", "types-defusedxml", "types-docutils", "types-networkx", "types-openpyxl", "types-pexpect", "types-psutil", "types-pycurl", "types-python-dateutil", "types-pytz", "types-setuptools"]
+viz = ["cartopy (>=0.23)", "matplotlib", "nc-time-axis", "seaborn"]
 
 [[package]]
 name = "xbatcher"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ xrpatcher = { git = "https://github.com/jejjohnson/xrpatcher.git", tag = "v0.0.6
 xesmf = { git = "https://github.com/pangeo-data/xESMF.git", tag = "v0.9.2" }
 dcleaderboard = { git = "https://github.com/ocean-ai-data-challenges/dc_leaderboard", branch = "main" }
 
-
 [tool.poetry.group.docs]
 optional = true
 


### PR DESCRIPTION
fix: robustness improvements across catalog, loader, evaluator and docs

- catalog/dataset: respect explicit `observation_dataset` YAML override
  instead of relying solely on coord_system auto-detection; guard None
  date_start/date_end in serialization; improve catalog-build log banner
- loader: add _fix_nanosecond_time() for zarr stores using non-CF
  'nanoseconds since' time units; handle cftime object arrays in
  get_time_bound_values
- evaluator: add per-task watchdog (15 min cap, 2 retries) alongside
  batch-level stall watchdog; reduce stall timeout 1200→600 s; add
  _get_worker_rss_bytes for unmanaged-memory tracking; atomic tmp+rename
  for concurrent time_index.npy writes; re-create s3fs after
  clean_for_serialization nullifies fs
- oceanbench_metrics: unify chunks after transform to avoid inconsistent-
  chunks errors; misc fixes
- docs/README: align examples with real API (imports, CLI, signatures)